### PR TITLE
writes dismod file in order dictated by foreign key dependencies

### DIFF
--- a/docs/dismod.rst
+++ b/docs/dismod.rst
@@ -1,0 +1,5 @@
+Dismod Interface
+================
+
+.. automodule:: cascade.dismod.db.wrapper
+    :members:

--- a/docs/refmanual.rst
+++ b/docs/refmanual.rst
@@ -7,3 +7,4 @@ Cascade-AT Reference Manual
 
    core
    executor
+   dismod

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,7 @@ imagesize==1.0.0
 Jinja2==2.10
 livereload==2.5.2
 MarkupSafe==1.0
+networkx
 numpy==1.15.0
 packaging==17.1
 pandas==0.23.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=PEP420PackageFinder.find("src"),
     package_data={"cascade.executor": ["data/*.toml"]},
     package_dir={"": "src"},
-    install_requires=["numpy", "pandas", "scipy", "toml", "sqlalchemy"],
+    install_requires=["numpy", "pandas", "scipy", "toml", "sqlalchemy", "networkx"],
     extras_require={
         "testing": ["hypothesis", "pytest", "pytest-mock"],
         "documentation": ["sphinx", "sphinx_rtd_theme", "sphinx-autobuild", "sphinxcontrib-napoleon"],

--- a/src/cascade/dismod/db/metadata.py
+++ b/src/cascade/dismod/db/metadata.py
@@ -99,7 +99,7 @@ class Node(Base):
 
     node_id = Column(Integer(), primary_key=True)
     node_name = Column(String(), nullable=False, unique=True)
-    parent = Column(None, ForeignKey("node.node_id"), nullable=True)  # Parent is an id in _this_ table.
+    parent = Column(Integer(), nullable=True)  # Parent is an id in _this_ table.
 
 
 class Prior(Base):

--- a/src/cascade/dismod/db/wrapper.py
+++ b/src/cascade/dismod/db/wrapper.py
@@ -90,7 +90,7 @@ def _ordered_by_foreign_key_dependency(schema, tables_to_write):
     """
     dependency_graph = DiGraph()
 
-    if len(set(tables_to_write) - set(schema.tables.keys())) > 0:
+    if set(tables_to_write) - set(schema.tables.keys()):
         raise ValueError("Asking to write tables not in schema")
 
     for scan_name, scan_table in schema.tables.items():
@@ -99,6 +99,7 @@ def _ordered_by_foreign_key_dependency(schema, tables_to_write):
             target_name = foreign_key.target_fullname.split(".")[0]
             dependency_graph.add_edge(target_name, scan_name)
 
+    # The pure topological sort might be faster.
     # Use the full lexicographical sort because it makes testing deterministic.
     for next_table in lexicographical_topological_sort(dependency_graph):
         if next_table in tables_to_write:

--- a/tests/dismod/db/test_wrapper.py
+++ b/tests/dismod/db/test_wrapper.py
@@ -8,8 +8,12 @@ import pytest
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Float, Enum
 
-from cascade.dismod.db.wrapper import DismodFile, _get_engine, _validate_data
+from cascade.dismod.db.wrapper import (
+    DismodFile, _get_engine, _validate_data,
+    _ordered_by_foreign_key_dependency,
+)
 from cascade.dismod.db import DismodFileError
+from cascade.dismod.db.metadata import Base as DismodFileBase
 
 
 @pytest.fixture
@@ -27,6 +31,24 @@ def base_file(engine):
     dm_file.integrand = pd.DataFrame({"integrand_name": ["prevalence"]})
 
     return dm_file
+
+
+
+@pytest.mark.parametrize("input,expected", [
+    ("age time integrand density", "age density integrand time"),
+    ("density prior age", "age density prior"),
+    ("node", "node"),
+    ("weight_grid age time weight", "age time weight weight_grid"),
+    ("avgint node weight", "node weight avgint"),
+])
+def test_ordering_of_tables(input, expected):
+    out = list(_ordered_by_foreign_key_dependency(DismodFileBase.metadata, input.split()))
+    assert out == expected.split()
+
+
+def test_ordering_unhappy():
+    with pytest.raises(ValueError):
+        next(_ordered_by_foreign_key_dependency(DismodFileBase.metadata, "nonexistent age".split()))
 
 
 def test_wrong_type(base_file):


### PR DESCRIPTION
Even sqlite3 won't let you write tables with foreign keys that are written out-of-order because it needs to check the keys. This PR adds a function to the file wrapper that finds all foreign keys and sorts the tables by their dependency on each other.

- it adds a library dependency to the networkx library, because that has a trustworthy sorting algorithm. If you want to rewrite that later, it's a nice exercise and limits our dependencies.
- it takes the foreign key off of the node_id.parent because that's a self-key. That will _never_ work with pandas updates to the database.
- adds docs for the Dismod file to the references section, which we should augment over time.