### PR TITLE
Fix sorting of priors where name is None

### DIFF
--- a/src/cascade/model/priors.py
+++ b/src/cascade/model/priors.py
@@ -26,9 +26,10 @@ class _Prior:
     def __lt__(self, other):
         if not isinstance(other, _Prior):
             return NotImplemented
-        return list(dict(name=self.name, **self.parameters()).items()) < list(
-            dict(name=other.name, **other.parameters()).items()
-        )
+        self_dict = sorted(dict(name=self.name if self.name else "", **self.parameters()).items())
+        other_dict = sorted(dict(name=other.name if other.name else "", **other.parameters()).items())
+
+        return self_dict < other_dict
 
     def __repr__(self):
         return f"<{type(self).__name__} {self.parameters()}>"

--- a/tests/model/test_priors.py
+++ b/tests/model/test_priors.py
@@ -57,6 +57,19 @@ def test_prior_nonequality():
     assert a != b
 
 
+def test_prior_sort():
+    priors = [
+        UniformPrior(lower=1e-10, upper=1, mean=5e-5, name="iota"),
+        GaussianPrior(0, 1, name="other_test_prior"),
+        UniformPrior(0, 1),
+    ]
+
+    # NOTE: This is a weak test of actual sorting behavior however all I
+    # actually care about is that the sort is stable, I don't really care
+    # what the order is
+    assert sorted(priors) == sorted(reversed(priors))
+
+
 def test_prior_hashing():
     s = {GaussianPrior(0, 1), UniformPrior(0, 1), GaussianPrior(0, 1), UniformPrior(0, 2), UniformPrior(0, 1)}
 


### PR DESCRIPTION
This resolves an issue Greg had where setting a name on a Prior object and then attempting to serialize the model in the presence of other Priors without names failed.