### PR TITLE
Add 'eta' to all priors

### DIFF
--- a/src/cascade/dismod/serialize.py
+++ b/src/cascade/dismod/serialize.py
@@ -300,6 +300,14 @@ def _prior_row(prior):
     }
     row.update(prior.parameters())
     row["density_name"] = row["density"]
+
+    if row["eta"] is None:
+        # For some distributions eta is a required parameter but for others
+        # it is nullable and represents an offset to be used during
+        # optimization. This let's us have None represent the missing
+        # value in python
+        row["eta"] = np.nan
+
     del row["density"]
     return row
 

--- a/src/cascade/model/priors.py
+++ b/src/cascade/model/priors.py
@@ -1,5 +1,12 @@
 from functools import total_ordering
 
+# TODO: Several of these prior types accept eta as a parameter and the others
+# don't use it as a parameter but use it as an offset in the optimization
+# process only if certain conditions are met. I think that means that the
+# offset case should be represented differently and there is also a validation
+# of eta for that case which could be done but isn't. For more details see the
+# docs: https://bradbell.github.io/dismod_at/doc/prior_table.htm#eta.Scaling%20Fixed%20Effects
+
 
 @total_ordering
 class _Prior:
@@ -53,7 +60,7 @@ def _validate_nu(nu):
 class UniformPrior(_Prior):
     density = "uniform"
 
-    def __init__(self, lower, upper, mean=None, name=None):
+    def __init__(self, lower, upper, mean=None, eta=None, name=None):
         super().__init__(name=name)
         if mean is None:
             mean = (upper + lower) / 2
@@ -62,9 +69,10 @@ class UniformPrior(_Prior):
         self.lower = lower
         self.upper = upper
         self.mean = mean
+        self.eta = eta
 
     def _parameters(self):
-        return {"lower": self.lower, "upper": self.upper, "mean": self.mean}
+        return {"lower": self.lower, "upper": self.upper, "mean": self.mean, "eta": self.eta}
 
 
 class ConstantPrior(_Prior):
@@ -81,7 +89,7 @@ class ConstantPrior(_Prior):
 class GaussianPrior(_Prior):
     density = "gaussian"
 
-    def __init__(self, mean, standard_deviation, lower=float("-inf"), upper=float("inf"), name=None):
+    def __init__(self, mean, standard_deviation, lower=float("-inf"), upper=float("inf"), eta=None, name=None):
         super().__init__(name=name)
         _validate_bounds(lower, mean, upper)
         _validate_standard_deviation(standard_deviation)
@@ -90,9 +98,16 @@ class GaussianPrior(_Prior):
         self.upper = upper
         self.mean = mean
         self.standard_deviation = standard_deviation
+        self.eta = eta
 
     def _parameters(self):
-        return {"lower": self.lower, "upper": self.upper, "mean": self.mean, "std": self.standard_deviation}
+        return {
+            "lower": self.lower,
+            "upper": self.upper,
+            "mean": self.mean,
+            "std": self.standard_deviation,
+            "eta": self.eta,
+        }
 
 
 class LaplacePrior(GaussianPrior):
@@ -102,7 +117,7 @@ class LaplacePrior(GaussianPrior):
 class StudentsTPrior(_Prior):
     density = "students"
 
-    def __init__(self, mean, standard_deviation, nu, lower=float("-inf"), upper=float("inf"), name=None):
+    def __init__(self, mean, standard_deviation, nu, lower=float("-inf"), upper=float("inf"), eta=None, name=None):
         super().__init__(name=name)
         _validate_bounds(lower, mean, upper)
         _validate_standard_deviation(standard_deviation)
@@ -113,6 +128,7 @@ class StudentsTPrior(_Prior):
         self.mean = mean
         self.standard_deviation = standard_deviation
         self.nu = nu
+        self.eta = eta
 
     def _parameters(self):
         return {
@@ -121,6 +137,7 @@ class StudentsTPrior(_Prior):
             "mean": self.mean,
             "std": self.standard_deviation,
             "nu": self.nu,
+            "eta": self.eta,
         }
 
 

--- a/tests/dismod/test_serialize.py
+++ b/tests/dismod/test_serialize.py
@@ -175,7 +175,10 @@ def test_make_prior_table(base_context):
 
         assert set(r_dict.keys()) == set(o_dict.keys())
         for k, v in r_dict.items():
-            assert r_dict[k] == o_dict[k] or (np.isnan(r_dict[k]) and np.isnan(o_dict[k]))
+            if k == "eta" and o_dict[k] is None:
+                assert np.isnan(r_dict[k])
+            else:
+                assert r_dict[k] == o_dict[k] or (np.isnan(r_dict[k]) and np.isnan(o_dict[k]))
 
 
 def test_make_smooth_and_smooth_grid_tables(base_context):

--- a/tests/model/test_priors.py
+++ b/tests/model/test_priors.py
@@ -12,13 +12,16 @@ from cascade.model.priors import (
 
 
 def test_happy_construction():
-    UniformPrior(-1, 1, 0, "test")
-    GaussianPrior(0, 1, -10, 10, "test2")
-    LaplacePrior(0, 1, -10, 10, "test3")
-    StudentsTPrior(0, 1, 0.5, -10, 10, "test4")
-    LogGaussianPrior(0, 1, 0.5, -10, 10, "test5")
-    LogLaplacePrior(0, 1, 0.5, -10, 10, "test6")
-    LogStudentsTPrior(0, 1, 0.5, 0.5, -10, 10, "test7")
+    UniformPrior(-1, 1, 0, name="test")
+    UniformPrior(-1, 1, 0, 0.5, name="test")
+    GaussianPrior(0, 1, -10, 10, name="test2")
+    GaussianPrior(0, 1, -10, 10, 0.5, name="test2")
+    LaplacePrior(0, 1, -10, 10, name="test3")
+    LaplacePrior(0, 1, -10, 10, 0.5, name="test3")
+    StudentsTPrior(0, 1, 0.5, -10, 10, name="test4")
+    LogGaussianPrior(0, 1, 0.5, -10, 10, name="test5")
+    LogLaplacePrior(0, 1, 0.5, -10, 10, name="test6")
+    LogStudentsTPrior(0, 1, 0.5, 0.5, -10, 10, name="test7")
 
 
 def test_prior_equality():


### PR DESCRIPTION
I missed a line in Brad's docs when I built out the prior objects initially. Turns out any prior can have an 'eta' parameter because it is used to offset the distribution under some circumstances. Details here: https://bradbell.github.io/dismod_at/doc/prior_table.htm#eta.Scaling%20Fixed%20Effects