### PR TITLE
Bugfix/allow writing of covariate columns

### DIFF
--- a/src/cascade/dismod/db/metadata.py
+++ b/src/cascade/dismod/db/metadata.py
@@ -4,6 +4,8 @@ This describes the tables in the sqlite file that Dismod reads.
 import enum
 import logging
 
+import numpy as np
+
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, String, Float, Enum, ForeignKey
 from sqlalchemy import BigInteger
@@ -532,7 +534,7 @@ class Var(Base):
     covariate_id = Column(Integer(), nullable=False)
 
 
-_TYPE_MAP = {str: String, int: Integer, float: Float}
+_TYPE_MAP = {str: String, int: Integer, float: Float, np.dtype("int64"): Integer, np.dtype("float64"): Float}
 
 
 def add_columns_to_avgint_table(metadata, column_identifiers):

--- a/src/cascade/dismod/db/wrapper.py
+++ b/src/cascade/dismod/db/wrapper.py
@@ -183,16 +183,16 @@ class DismodFile:
 
     def update_table_columns(self, table_definition, table):
         new_columns = table.columns.difference(table_definition.c.keys())
-        new_columns = {c: table.dtypes[c] for c in new_columns}
+        new_column_types = {c: table.dtypes[c] for c in new_columns}
 
-        bad_column_names = [c for c in new_columns.keys() if not c.startswith("x_")]
+        bad_column_names = [c for c in new_columns if not c.startswith("x_")]
         if bad_column_names:
             raise ValueError(f"Covariate column names must start with 'x_'. Malformed names: {bad_column_names}")
 
         if table_definition.name == "avgint":
-            add_columns_to_avgint_table(self._metadata, new_columns)
+            add_columns_to_avgint_table(self._metadata, new_column_types)
         elif table_definition.name == "data":
-            add_columns_to_data_table(self._metadata, new_columns)
+            add_columns_to_data_table(self._metadata, new_column_types)
         else:
             raise ValueError(f"Can't add columns to {table.name}")
 

--- a/src/cascade/dismod/db/wrapper.py
+++ b/src/cascade/dismod/db/wrapper.py
@@ -187,7 +187,7 @@ class DismodFile:
 
         bad_column_names = [c for c in new_columns.keys() if not c.startswith("x_")]
         if bad_column_names:
-            raise ValueError("Covariate column names must start with 'x_'")
+            raise ValueError(f"Covariate column names must start with 'x_'. Malformed names: {bad_column_names}")
 
         if table_definition.name == "avgint":
             add_columns_to_avgint_table(self._metadata, new_columns)
@@ -209,7 +209,7 @@ class DismodFile:
             except ValueError as e:
                 if str(e) != f"Table {table.name} not found":
                     raise
-                data = pd.DataFrame({k: pd.Series(dtype=v.type.python_type) for k, v in table.c.items()})
+                data = self.empty_table(table.name)
 
             extra_columns = set(data.columns.difference(table.c.keys()))
             if extra_columns:
@@ -362,7 +362,4 @@ class DismodFile:
             An empty dataframe, but columns have correcct types.
         """
         table_definition = self._table_definitions[table_name]
-        # Skip the first one. It's always the column_id.
-        dtypes = [(k, v.type) for k, v in table_definition.c.items()][1:]
-        type_map = {Integer: np.int, Float: np.float, String: np.str, Enum: np.str}
-        return pd.DataFrame({column: np.zeros(0, dtype=type_map[type(kind)]) for column, kind in dtypes})
+        return pd.DataFrame({k: pd.Series(dtype=v.type.python_type) for k, v in table_definition.c.items()})

--- a/tests/dismod/db/test_wrapper.py
+++ b/tests/dismod/db/test_wrapper.py
@@ -21,7 +21,7 @@ def engine():
 
 @pytest.fixture
 def base_file(engine):
-    dm_file = DismodFile(engine, {"howdy": float}, {"there": int})
+    dm_file = DismodFile(engine)
     dm_file.make_densities()
     ages = pd.DataFrame({"age": np.array([6.0, 22.0, 48.0])})
     ages["age_id"] = ages.index
@@ -82,7 +82,7 @@ def test_is_dirty__after_modification(base_file):
 def test_is_dirty__on_read(base_file, engine):
     base_file.flush()
 
-    dm_file2 = DismodFile(engine, {"howdy": float}, {"there": int})
+    dm_file2 = DismodFile(engine)
 
     dm_file2.age
 
@@ -112,7 +112,7 @@ def test_dmfile_read(base_file, engine):
     times = base_file.time
     base_file.flush()
 
-    dm_file2 = DismodFile(engine, {"howdy": float}, {"there": int})
+    dm_file2 = DismodFile(engine)
     assert ages.sort_index("columns").equals(dm_file2.age.sort_index("columns"))
     assert times.sort_index("columns").equals(dm_file2.time.sort_index("columns"))
 
@@ -123,7 +123,7 @@ def test_reading_modified_columns(base_file, engine):
     ages = base_file.age.copy()
     base_file.flush()
 
-    dm_file2 = DismodFile(engine, {"howdy": float}, {"there": int})
+    dm_file2 = DismodFile(engine)
     assert ages.sort_index("columns").equals(dm_file2.age.sort_index("columns"))
 
 
@@ -189,42 +189,55 @@ def test_validate_data__missing_column():
     assert "nonnullable_column" in str(excinfo.value)
 
 
-def test_two_files_different_columns():
-    column_sets = [{"howdy": float}, {"there": int}]
-    dm_files = list()
-    for column_set in column_sets:
-        engine = _get_engine(None)
-        dm_file = DismodFile(engine, column_set, column_set)
-        dm_file.integrand = pd.DataFrame(
-            {"integrand_id": [0], "integrand_name": ["Sincidence"], "minimum_meas_cv": [0.0]}
-        )
-        dm_file.density = pd.DataFrame({"density_id": [0], "density_name": ["uniform"]})
-        dm_file.node = pd.DataFrame({"node_id": [0], "node_name": ["Foreverland"], "parent": [np.NaN]})
-        dm_file.weight = pd.DataFrame({"weight_id": [0], "weight_name": ["uniform"], "n_age": [1], "n_time": [1]})
-        common_input = {
-            "data_id": [0],
-            "data_name": ["only"],
-            "integrand_id": [0],
-            "density_id": [0],
-            "node_id": [0],
-            "weight_id": [0],
-            "hold_out": [0],
-            "meas_value": [1.0],
-            "meas_std": [0.1],
-            "eta": [0.0],
-            "nu": [0.0],
-            "age_lower": [0.0],
-            "age_upper": [10.0],
-            "time_lower": [1971],
-            "time_upper": [2020],
-        }
-        for col_title, col_type in column_set.items():
-            common_input[col_title] = col_type()
+def test_write_covariate_column__success(base_file):
+    new_data = pd.DataFrame(
+        {
+            "data_name": "foo",
+            "integrand_id": 1,
+            "density_id": 1,
+            "node_id": 1,
+            "weight_id": 1,
+            "hold_out": 0,
+            "meas_value": 0.0,
+            "meas_std": 0.0,
+            "eta": np.nan,
+            "nu": np.nan,
+            "age_lower": 0,
+            "age_upper": 10,
+            "time_lower": 1990,
+            "time_upper": 2000,
+            "x_s_source": 0,
+            "x_sex": 2.0,
+        },
+        index=[0],
+    )
+    base_file.data = new_data
+    base_file.flush()
 
-        dm_file.data = pd.DataFrame(common_input)
-        dm_file.flush()
-        dm_files.append(dm_file)
 
-    for check_set, in_file in zip(column_sets, dm_files):
-        for check_col in check_set:
-            assert check_col in in_file.data.columns
+def test_write_covariate_column__bad_name(base_file):
+    new_data = pd.DataFrame(
+        {
+            "data_name": "foo",
+            "integrand_id": 1,
+            "density_id": 1,
+            "node_id": 1,
+            "weight_id": 1,
+            "hold_out": 0,
+            "meas_value": 0.0,
+            "meas_std": 0.0,
+            "eta": np.nan,
+            "nu": np.nan,
+            "age_lower": 0,
+            "age_upper": 10,
+            "time_lower": 1990,
+            "time_upper": 2000,
+            "x_s_source": 0,
+            "not_x_sex": 2.0,
+        },
+        index=[0],
+    )
+    base_file.data = new_data
+    with pytest.raises(ValueError) as excinfo:
+        base_file.flush()
+    assert "Covariate column names must start with 'x_'" == str(excinfo.value)

--- a/tests/dismod/db/test_wrapper.py
+++ b/tests/dismod/db/test_wrapper.py
@@ -215,8 +215,9 @@ def test_write_covariate_column__success(base_file):
     base_file.flush()
 
 
-def test_read_covariate_column__success(base_file):
-    new_data = pd.DataFrame(
+@pytest.fixture
+def dummy_data_row():
+    return pd.DataFrame(
         {
             "data_name": "foo",
             "integrand_id": 1,
@@ -237,7 +238,10 @@ def test_read_covariate_column__success(base_file):
         },
         index=[0],
     )
-    base_file.data = new_data
+
+
+def test_read_covariate_column__success(base_file, dummy_data_row):
+    base_file.data = dummy_data_row
     base_file.flush()
 
     new_dm = DismodFile(base_file.engine)
@@ -245,29 +249,9 @@ def test_read_covariate_column__success(base_file):
     assert list(new_dm.data.x_sex) == [2.0]
 
 
-def test_write_covariate_column__bad_name(base_file):
-    new_data = pd.DataFrame(
-        {
-            "data_name": "foo",
-            "integrand_id": 1,
-            "density_id": 1,
-            "node_id": 1,
-            "weight_id": 1,
-            "hold_out": 0,
-            "meas_value": 0.0,
-            "meas_std": 0.0,
-            "eta": np.nan,
-            "nu": np.nan,
-            "age_lower": 0,
-            "age_upper": 10,
-            "time_lower": 1990,
-            "time_upper": 2000,
-            "x_s_source": 0,
-            "not_x_sex": 2.0,
-        },
-        index=[0],
-    )
-    base_file.data = new_data
+def test_write_covariate_column__bad_name(base_file, dummy_data_row):
+    dummy_data_row = dummy_data_row.rename(columns={"x_sex": "not_x_sex"})
+    base_file.data = dummy_data_row
     with pytest.raises(ValueError) as excinfo:
         base_file.flush()
     assert "Covariate column names must start with 'x_'" == str(excinfo.value)

--- a/tests/dismod/db/test_wrapper.py
+++ b/tests/dismod/db/test_wrapper.py
@@ -215,6 +215,36 @@ def test_write_covariate_column__success(base_file):
     base_file.flush()
 
 
+def test_read_covariate_column__success(base_file):
+    new_data = pd.DataFrame(
+        {
+            "data_name": "foo",
+            "integrand_id": 1,
+            "density_id": 1,
+            "node_id": 1,
+            "weight_id": 1,
+            "hold_out": 0,
+            "meas_value": 0.0,
+            "meas_std": 0.0,
+            "eta": np.nan,
+            "nu": np.nan,
+            "age_lower": 0,
+            "age_upper": 10,
+            "time_lower": 1990,
+            "time_upper": 2000,
+            "x_s_source": 0,
+            "x_sex": 2.0,
+        },
+        index=[0],
+    )
+    base_file.data = new_data
+    base_file.flush()
+
+    new_dm = DismodFile(base_file.engine)
+    assert list(new_dm.data.x_s_source) == [0]
+    assert list(new_dm.data.x_sex) == [2.0]
+
+
 def test_write_covariate_column__bad_name(base_file):
     new_data = pd.DataFrame(
         {

--- a/tests/dismod/test_serialize.py
+++ b/tests/dismod/test_serialize.py
@@ -91,7 +91,7 @@ def test_development_target(base_context):
     e = _get_engine(None)
     dm.engine = e
     dm.flush()
-    dm2 = DismodFile(e, {}, {})
+    dm2 = DismodFile(e)
 
     age_table = make_age_table(base_context)
     time_table = make_time_table(base_context)
@@ -153,7 +153,7 @@ def test_make_time_table(base_context):
 
 
 def test_make_prior_table(base_context):
-    dm = DismodFile(None, {}, {})
+    dm = DismodFile(None)
     dm.make_densities()
 
     prior_table, prior_id_func = make_prior_table(base_context, dm.density)
@@ -188,7 +188,7 @@ def test_make_prior_table(base_context):
 
 
 def test_make_smooth_and_smooth_grid_tables(base_context):
-    dm = DismodFile(None, {}, {})
+    dm = DismodFile(None)
     dm.make_densities()
 
     age_table = make_age_table(base_context)
@@ -234,7 +234,7 @@ def test_make_avgint_table(base_context):
 
 
 def test_make_rate_table(base_context):
-    dm = DismodFile(None, {}, {})
+    dm = DismodFile(None)
     dm.make_densities()
     age_table = make_age_table(base_context)
     time_table = make_time_table(base_context)

--- a/tests/saver/test_generate_draws.py
+++ b/tests/saver/test_generate_draws.py
@@ -1,9 +1,7 @@
 import pandas as pd
 import pytest
 
-from cascade.saver.generate_draws import (
-    generate_draws_table,
-    pure_generate_draws)
+from cascade.saver.generate_draws import generate_draws_table, pure_generate_draws
 from cascade.dismod.db.wrapper import _get_engine, DismodFile
 
 
@@ -23,21 +21,9 @@ def avgint_df():
 @pytest.fixture(scope="module")
 def predict_df():
     predict_df = pd.DataFrame()
-    predict_df["sample_index"] = [
-        0, 0, 0, 0,
-        1, 1, 1, 1,
-        2, 2, 2, 2,
-        3, 3, 3, 3]
-    predict_df["avgint_id"] = [
-        3, 0, 1, 2,
-        0, 1, 2, 3,
-        0, 1, 2, 3,
-        0, 1, 2, 3]
-    predict_df["avg_integrand"] = [
-        4, 1, 2, 3,
-        5, 6, 7, 8,
-        9, 10, 11, 12,
-        13, 14, 15, 16]
+    predict_df["sample_index"] = [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]
+    predict_df["avgint_id"] = [3, 0, 1, 2, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
+    predict_df["avg_integrand"] = [4, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 
     return predict_df
 
@@ -45,7 +31,7 @@ def predict_df():
 @pytest.fixture(scope="module")
 def dismod_file(avgint_df, predict_df):
     engine = _get_engine(None)
-    dismod_file = DismodFile(engine, {}, {})
+    dismod_file = DismodFile(engine)
     dismod_file.avgint = avgint_df
     dismod_file.predict = predict_df
 
@@ -55,7 +41,7 @@ def dismod_file(avgint_df, predict_df):
 @pytest.fixture(scope="module")
 def dismod_file_avgint_df_empty(predict_df):
     engine = _get_engine(None)
-    dismod_file_avgint_df_empty = DismodFile(engine, {}, {})
+    dismod_file_avgint_df_empty = DismodFile(engine)
     dismod_file_avgint_df_empty.avgint = pd.DataFrame()
     dismod_file_avgint_df_empty.predict = predict_df
 
@@ -65,7 +51,7 @@ def dismod_file_avgint_df_empty(predict_df):
 @pytest.fixture(scope="module")
 def dismod_file_predict_df_empty(avgint_df):
     engine = _get_engine(None)
-    dismod_file_predict_df_empty = DismodFile(engine, {}, {})
+    dismod_file_predict_df_empty = DismodFile(engine)
     dismod_file_predict_df_empty.avgint = avgint_df
     dismod_file_predict_df_empty.predict = pd.DataFrame()
 
@@ -75,8 +61,7 @@ def dismod_file_predict_df_empty(avgint_df):
 @pytest.fixture(scope="module")
 def predict_df_ragged(predict_df):
     predict_df_copy = predict_df.copy()
-    extra_data = {"sample_index": [4, 4], "avgint_id": [0, 1],
-                  "avg_integrand": [17, 18]}
+    extra_data = {"sample_index": [4, 4], "avgint_id": [0, 1], "avg_integrand": [17, 18]}
     extra_rows_df = pd.DataFrame(extra_data)
 
     predict_df_ragged = predict_df_copy.append(extra_rows_df)
@@ -104,8 +89,7 @@ def test_generate_draws_table(dismod_file):
 
     draws_df = generate_draws_table(dismod_file)
 
-    pd.testing.assert_frame_equal(draws_df, expected_draws_df(),
-                                  check_like=True)
+    pd.testing.assert_frame_equal(draws_df, expected_draws_df(), check_like=True)
 
 
 def test_generate_draws_empty_avgint(dismod_file_avgint_df_empty):
@@ -124,8 +108,17 @@ def test_pure_generate_draws(avgint_df, predict_df, expected_draws_df):
 
     assert draws_df.shape == (4, 9)
 
-    expected_columns = ["location_id", "age_group_id", "year_id", "sex_id",
-                        "integrand_id", "draw_0", "draw_1", "draw_2", "draw_3"]
+    expected_columns = [
+        "location_id",
+        "age_group_id",
+        "year_id",
+        "sex_id",
+        "integrand_id",
+        "draw_0",
+        "draw_1",
+        "draw_2",
+        "draw_3",
+    ]
 
     assert set(draws_df.columns) == set(expected_columns)
 


### PR DESCRIPTION
This lets us define covariate columns from the actual schema of pandas tables. It also makes the precondition checks on the column names tighter.

One limitation with this is that it won't remove columns, only add. I'm not sure if that's an issue.