### PR TITLE
Feature/dismodat 274 load parameters

### DIFF
--- a/examples/simple_load_from_epiviz.py
+++ b/examples/simple_load_from_epiviz.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-import pprint
+from pprint import pprint
 from argparse import ArgumentParser
 
 from cascade.dismod.db.wrapper import _get_engine
 from cascade.testing_utilities import make_execution_context
 from cascade.core.db import latest_model_version
-from cascade.input_data.db.configuration import from_epiviz
+from cascade.input_data.db.configuration import settings_json_from_epiviz
 from cascade.executor.no_covariate_main import bundle_to_observations
 from cascade.input_data.configuration.form import Configuration
 from cascade.input_data.db.bundle import bundle_with_study_covariates, freeze_bundle
@@ -18,7 +18,7 @@ from cascade.input_data.configuration.builder import (
 
 
 def model_context_from_epiviz(execution_context):
-    config_data = from_epiviz(execution_context)
+    config_data = settings_json_from_epiviz(execution_context)
     configuration = Configuration(config_data)
     errors = configuration.validate_and_normalize()
     if errors:

--- a/examples/simple_load_from_epiviz.py
+++ b/examples/simple_load_from_epiviz.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import pprint
+from argparse import ArgumentParser
+
+from cascade.dismod.db.wrapper import _get_engine
+from cascade.testing_utilities import make_execution_context
+from cascade.core.db import latest_model_version
+from cascade.input_data.db.configuration import from_epiviz
+from cascade.executor.no_covariate_main import bundle_to_observations
+from cascade.input_data.configuration.form import Configuration
+from cascade.input_data.db.bundle import bundle_with_study_covariates, freeze_bundle
+from cascade.dismod.serialize import model_to_dismod_file
+from cascade.input_data.configuration.builder import (
+    initial_context_from_epiviz,
+    fixed_effects_from_epiviz,
+    integrand_grids_from_epiviz,
+)
+
+
+def model_context_from_epiviz(execution_context):
+    config_data = from_epiviz(execution_context)
+    configuration = Configuration(config_data)
+    errors = configuration.validate_and_normalize()
+    if errors:
+        pprint(config_data)
+        pprint(errors)
+        raise ValueError("Configuration does not validate")
+
+    model_context = initial_context_from_epiviz(configuration)
+
+    fixed_effects_from_epiviz(model_context, configuration.rate)
+
+    freeze_bundle(execution_context)
+
+    bundle, study_covariates = bundle_with_study_covariates(
+        execution_context, bundle_id=model_context.parameters.bundle_id
+    )
+    model_context.inputs = bundle_to_observations(model_context.parameters, bundle)
+
+    integrand_grids_from_epiviz(model_context, configuration)
+
+    return model_context
+
+
+def main():
+    parser = ArgumentParser("Build a simple model from Epiviz")
+    parser.add_argument("db_file_path")
+    parser.add_argument("--meid", type=int)
+    parser.add_argument("--mvid", type=int)
+    args = parser.parse_args()
+
+    if args.mvid:
+        mvid = args.mvid
+    elif args.meid:
+        modelable_entity_id = args.meid
+        ec = make_execution_context(modelable_entity_id=modelable_entity_id)
+        mvid = latest_model_version(ec)
+    else:
+        raise ValueError("Must supply either mvid or meid")
+
+    ec = make_execution_context(model_version_id=mvid)
+    mc = model_context_from_epiviz(ec)
+
+    dismod_file = model_to_dismod_file(mc)
+    dismod_file.engine = _get_engine(Path(args.db_file_path))
+    dismod_file.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/simple_load_from_epiviz.py
+++ b/examples/simple_load_from_epiviz.py
@@ -28,14 +28,14 @@ def model_context_from_epiviz(execution_context):
 
     model_context = initial_context_from_epiviz(configuration)
 
-    fixed_effects_from_epiviz(model_context, configuration.rate)
+    fixed_effects_from_epiviz(model_context, configuration)
 
     freeze_bundle(execution_context)
 
     bundle, study_covariates = bundle_with_study_covariates(
         execution_context, bundle_id=model_context.parameters.bundle_id
     )
-    model_context.inputs = bundle_to_observations(model_context.parameters, bundle)
+    model_context.input_data.observations = bundle_to_observations(model_context.parameters, bundle)
 
     integrand_grids_from_epiviz(model_context, configuration)
 

--- a/src/cascade/core/form/fields.py
+++ b/src/cascade/core/form/fields.py
@@ -27,17 +27,18 @@ class FormList(Form):
       inner_form_constructor: A factory which produces an instance of a Form
       subclass. Most often it will just be the Form subclass itself.
     """
+
     def __init__(self, inner_form_constructor, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.inner_form_constructor = inner_form_constructor
+        self._inner_form_constructor = inner_form_constructor
         self._forms = []
         self._args = [inner_form_constructor] + self._args
 
     def process_source(self, source):
         forms = []
         for i, inner_source in enumerate(source):
-            form = self.inner_form_constructor()
-            form.name = str(i)
+            form = self._inner_form_constructor()
+            form._name = str(i)
             form.process_source(inner_source)
             forms.append(form)
         self._forms = forms
@@ -66,6 +67,7 @@ class Dummy(Field):
     sections of the configuration which have yet to be implemented and should
     be ignored.
     """
+
     def validate_and_normalize(self, instance):
         return []
 
@@ -87,6 +89,7 @@ class OptionField(SimpleTypeField):
         constructor: A function which takes a string and returns the expected
           type. Behaves as the constructor for SimpleTypeField. Defaults to str
     """
+
     def __init__(self, options, *args, constructor=str, **kwargs):
         super().__init__(constructor, *args, **kwargs)
         self.options = options
@@ -112,6 +115,7 @@ class StringListField(SimpleTypeField):
           type. Behaves as the constructor for SimpleTypeField. Defaults to str
         separator (str): The string to split by. Defaults to a single space.
     """
+
     def __init__(self, *args, constructor=str, separator=" ", **kwargs):
         super().__init__(constructor, *args, **kwargs)
         self.separator = separator

--- a/src/cascade/dismod/serialize.py
+++ b/src/cascade/dismod/serialize.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from cascade.dismod.db.metadata import IntegrandEnum, DensityEnum
 from cascade.dismod.db.wrapper import DismodFile
-from cascade.model.priors import ConstantPrior
+from cascade.model.priors import Constant
 from cascade.model.grids import unique_floats
 
 
@@ -129,7 +129,7 @@ def make_log_table():
 def make_node_table(context):
     # Assume we have one location, so no parents.
     # If we had a hierarchy, that would be used to determine parents.
-    if context.input_data.observations is not None:
+    if context.input_data.observations is not None and not context.input_data.observations.empty:
         unique_locations = context.input_data.observations["location_id"].unique()
         assert len(unique_locations) == 1
     else:
@@ -214,9 +214,9 @@ def collect_priors(context):
                 if grid:
                     ps = grid.priors
                     if grid_name == "value_priors":
-                        # ConstantPriors on the value don't actually go in the
+                        # Constants on the value don't actually go in the
                         # prior table, so exclude them
-                        ps = [p for p in ps if not isinstance(p, ConstantPrior)]
+                        ps = [p for p in ps if not isinstance(p, Constant)]
                     priors.update(ps)
 
     return priors
@@ -345,7 +345,7 @@ def make_smooth_grid_table(smooth, prior_id_func):
                 row = {"age": float(age), "time": float(year), "const_value": np.nan}
                 if smooth.value_priors:
                     prior = smooth.value_priors[age, year].prior
-                    if isinstance(prior, ConstantPrior):
+                    if isinstance(prior, Constant):
                         row["const_value"] = prior.value
                         row["value_prior_id"] = np.nan
                     else:

--- a/src/cascade/executor/no_covariate_main.py
+++ b/src/cascade/executor/no_covariate_main.py
@@ -38,7 +38,7 @@ from cascade.dismod.db.wrapper import _get_engine
 from cascade.core.context import ModelContext
 from cascade.dismod.serialize import model_to_dismod_file
 from cascade.model.grids import AgeTimeGrid, PriorGrid
-from cascade.model.priors import UniformPrior, ConstantPrior, NO_PRIOR
+from cascade.model.priors import Uniform, Constant, NO_PRIOR
 from cascade.model.rates import Smooth
 
 
@@ -186,7 +186,7 @@ def build_constraint(constraint):
     value_prior = PriorGrid(grid)
     # TODO: change the PriorGrid API to handle this elegantly
     for _, row in constraint.iterrows():
-        value_prior[row["age_start"], row["year_start"]].prior = ConstantPrior(row["mean"])
+        value_prior[row["age_start"], row["year_start"]].prior = Constant(row["mean"])
     return Smooth(smoothing_prior, smoothing_prior, value_prior)
 
 
@@ -199,7 +199,7 @@ def internal_model(model, inputs):
     grid = age_year_from_data(inputs.constraints)
 
     priors = PriorGrid(grid)
-    priors[:, :].prior = UniformPrior(1e-10, 1.0, 0.01)
+    priors[:, :].prior = Uniform(1e-10, 1.0, 0.01)
     default_smoothing = Smooth(priors, priors, priors)
 
     # No smoothing for initial prevalence in Brad's example.

--- a/src/cascade/input_data/configuration/builder.py
+++ b/src/cascade/input_data/configuration/builder.py
@@ -1,0 +1,105 @@
+from cascade.model.grids import AgeTimeGrid, PriorGrid
+from cascade.model.rates import Smooth
+import cascade.model.priors as priors
+from cascade.input_data.configuration import ConfigurationError
+from cascade.core.context import ModelContext
+from cascade.dismod.db.metadata import IntegrandEnum
+
+RATE_TO_INTEGRAND = dict(
+    iota=IntegrandEnum.Sincidence,
+    rho=IntegrandEnum.remission,
+    chi=IntegrandEnum.mtexcess,
+    omega=IntegrandEnum.mtother,
+    prevalence=IntegrandEnum.prevalence,
+)
+
+
+def initial_context_from_epiviz(configuration):
+    context = ModelContext()
+    context.parameters.modelable_entity_id = configuration.model.modelable_entity_id
+    context.parameters.bundle_id = configuration.model.bundle_id
+    context.parameters.gbd_round_id = configuration.gbd_round_id
+    context.parameters.location_id = configuration.model.drill_location
+
+    return context
+
+
+def _make_prior(config):
+    result = None
+    try:
+        if config.density == "uniform":
+            result = priors.UniformPrior(config.min, config.max, config.mean)
+        elif config.density == "gaussian":
+            result = priors.GaussianPrior(
+                config.mean,
+                config.std,
+                config.min if config.min else float("-inf"),
+                config.max if config.max else float("inf"),
+            )
+        elif config.density == "laplace":
+            result = priors.LaplacePrior(
+                config.mean,
+                config.std,
+                config.min if config.min else float("-inf"),
+                config.max if config.max else float("inf"),
+            )
+    except (TypeError, ValueError):
+        raise ValueError(f"Supplied pramaters not compatible with density '{config.density}':" f"{config}")
+
+    if result is None:
+        raise ValueError(f"Unsuported density: '{config.density}'")
+
+    return result
+
+
+MEASURE_ID_TO_RATE_NAME = {
+    6: "iota",  # Incidence
+    7: "rho",  # Remission
+    9: "chi",  # Excess Mortality
+    16: "omega",
+    18: "proportion",
+    19: "continuous",
+    38: "birth_prevalence",
+}
+
+
+def fixed_effects_from_epiviz(model_context, rates_configuration):
+    for rate_config in rates_configuration:
+        rate_name = MEASURE_ID_TO_RATE_NAME[rate_config.rate]
+        if rate_name not in [r.name for r in model_context.rates]:
+            raise ConfigurationError(f"Unspported rate {rate_name}")
+        rate = getattr(model_context.rates, rate_name)
+        ages = rate_config.age_grid
+        times = rate_config.time_grid
+        grid = AgeTimeGrid(ages, times)
+
+        d_time = PriorGrid(grid)
+        d_age = PriorGrid(grid)
+        value = PriorGrid(grid)
+
+        d_age[:, :].prior = _make_prior(rate_config.default.dage)
+        d_time[:, :].prior = _make_prior(rate_config.default.dtime)
+        value[:, :].prior = _make_prior(rate_config.default.value)
+
+        for row in rate_config.detail:
+            if row.prior_type == "dage":
+                pgrid = d_age
+            elif row.prior_type == "dtime":
+                pgrid = d_time
+            elif row.prior_type == "value":
+                pgrid = value
+            else:
+                raise ConfigurationError(f"Unknown prior type {row.prior_type}")
+            pgrid[slice(row.age_lower, row.age_upper), slice(row.time_lower, row.time_upper)].prior = _make_prior(row)
+        rate.parent_smooth = Smooth(value, d_age, d_time)
+
+
+def integrand_grids_from_epiviz(model_context, configuration):
+    ages = configuration.model.default_age_grid
+    times = configuration.model.default_time_grid
+    grid = AgeTimeGrid(ages, times)
+
+    for rate in model_context.rates:
+        if rate.parent_smooth:
+            integrand = getattr(model_context.outputs.integrands, RATE_TO_INTEGRAND[rate.name].name)
+            integrand.grid = grid

--- a/src/cascade/input_data/configuration/builder.py
+++ b/src/cascade/input_data/configuration/builder.py
@@ -67,9 +67,7 @@ def fixed_effects_from_epiviz(model_context, configuration):
                     pgrid = value
                 else:
                     raise ConfigurationError(f"Unknown prior type {row.prior_type}")
-                pgrid[
-                    slice(row.age_lower, row.age_upper), slice(row.time_lower, row.time_upper)
-                ].prior = row.prior_object
+                pgrid[row.age_lower:row.age_upper, row.time_lower:row.time_upper].prior = row.prior_object
         rate.parent_smooth = Smooth(value, d_age, d_time)
 
 

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -83,8 +83,8 @@ class Smoothing(Form):
 
 class Model(Form):
     modelable_entity_id = IntField()
-    title = StrField()
-    description = StrField()
+    title = StrField(nullable=True)
+    description = StrField(nullable=True)
     bundle_id = IntField(nullable=True)
     drill = OptionField(["cascade", "drill"])
     drill_location = IntField()

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -42,19 +42,19 @@ class SmoothingPrior(Form):
 
         try:
             if self.density == "uniform":
-                self.prior_object = priors.UniformPrior(self.min, self.max, self.mean)
+                self.prior_object = priors.Uniform(self.min, self.max, self.mean)
             elif self.density == "gaussian":
-                self.prior_object = priors.GaussianPrior(self.mean, self.std, self.min, self.max)
+                self.prior_object = priors.Gaussian(self.mean, self.std, self.min, self.max)
             elif self.density == "laplace":
-                self.prior_object = priors.LaplacePrior(self.mean, self.std, self.min, self.max)
+                self.prior_object = priors.Laplace(self.mean, self.std, self.min, self.max)
             elif self.density == "students":
-                self.prior_object = priors.StudentsTPrior(self.mean, self.std, self.nu, self.min, self.max, self.eta)
+                self.prior_object = priors.StudentsT(self.mean, self.std, self.nu, self.min, self.max, self.eta)
             elif self.density == "log_gaussian":
-                self.prior_object = priors.LogGaussianPrior(self.mean, self.std, self.eta, self.min, self.max)
+                self.prior_object = priors.LogGaussian(self.mean, self.std, self.eta, self.min, self.max)
             elif self.density == "log_laplace":
-                self.prior_object = priors.LogLaplacePrior(self.mean, self.std, self.eta, self.min, self.max)
+                self.prior_object = priors.LogLaplace(self.mean, self.std, self.eta, self.min, self.max)
             elif self.density == "log_students":
-                self.prior_object = priors.LogStudentsTPrior(self.mean, self.std, self.nu, self.eta, self.min, self.max)
+                self.prior_object = priors.LogStudentsT(self.mean, self.std, self.nu, self.eta, self.min, self.max)
             else:
                 errors.append(f"Unknown density '{self.density}'")
         except priors.PriorError as e:
@@ -71,8 +71,8 @@ class SmoothingPriorGroup(Form):
 
 class Smoothing(Form):
     rate = IntField()
-    age_grid = StringListField(constructor=float)
-    time_grid = StringListField(constructor=float)
+    age_grid = StringListField(constructor=float, nullable=True)
+    time_grid = StringListField(constructor=float, nullable=True)
     default = SmoothingPriorGroup()
     mulstd = SmoothingPriorGroup(nullable=True)
     detail = FormList(SmoothingPrior, nullable=True)
@@ -110,12 +110,12 @@ class Configuration(Form):
 
     model = Model()
     gbd_round_id = IntField()
-    csmr_cod_output_version_id = IntField()
-    csmr_mortality_output_version_id = IntField()
-    location_set_version_id = IntField()
     random_effect = FormList(Smoothing, nullable=True)
     rate = FormList(Smoothing)
 
+    csmr_cod_output_version_id = Dummy()
+    csmr_mortality_output_version_id = Dummy()
+    location_set_version_id = Dummy()
     min_cv = FormList(Dummy)
     min_cv_by_rate = FormList(Dummy)
     re_bound_location = FormList(Dummy)

--- a/src/cascade/input_data/db/bundle.py
+++ b/src/cascade/input_data/db/bundle.py
@@ -13,7 +13,7 @@ from cascade.core.db import cursor, connection
 CODELOG = logging.getLogger(__name__)
 
 # FIXME: There is a shared function that get's the official mapping, I think. Or an sql query at least.
-MEASURES = {6: "incidence", 9: "mtexcess"}
+MEASURES = {6: "incidence", 9: "mtexcess", 5: "prevalence"}
 
 
 def _bundle_is_frozen(execution_context):

--- a/src/cascade/input_data/db/configuration.py
+++ b/src/cascade/input_data/db/configuration.py
@@ -1,0 +1,63 @@
+import json
+
+from cascade.core.db import cursor
+
+
+def from_epiviz(execution_context):
+    model_version_id = execution_context.parameters.model_version_id
+
+    query = """select parameter_json from at_model_parameter where model_version_id = %(model_version_id)s"""
+    with cursor(execution_context) as c:
+        c.execute(query, args={"model_version_id": model_version_id})
+        raw_data = c.fetchall()
+
+    if len(raw_data) == 0:
+        raise ValueError(f"No parameters for model version {model_version_id}")
+    if len(raw_data) > 1:
+        raise ValueError(f"Multiple parameter entries for model version {model_version_id}")
+
+    config_data = json.loads(raw_data[0][0])
+
+    # Fix bugs in epiviz
+    # TODO: remove this once EPI-999 is resolved
+    config_data = trim_config(config_data)
+    if config_data is DO_REMOVE:
+        config_data = {}
+
+    return config_data
+
+
+DO_REMOVE = object()
+
+
+def trim_config(source):
+    """ This function represents the approach to missing data which the viz
+    team says the will enforce in the front end, though that hasn't happened
+    yet.
+    """
+    trimmed = None
+    remove = True
+    if isinstance(source, dict):
+        trimmed = {}
+        for k, v in source.items():
+            if k.startswith("__"):
+                continue
+            tv = trim_config(v)
+            if tv is not DO_REMOVE:
+                trimmed[k] = tv
+                remove = False
+    elif isinstance(source, list):
+        trimmed = []
+        for v in source:
+            tv = trim_config(v)
+            if tv is not DO_REMOVE:
+                trimmed.append(tv)
+                remove = False
+    else:
+        if source is not None and source != "":
+            trimmed = source
+            remove = False
+
+    if remove:
+        return DO_REMOVE
+    return trimmed

--- a/src/cascade/model/grids.py
+++ b/src/cascade/model/grids.py
@@ -163,11 +163,11 @@ class PriorGrid:
         >>> grid = AgeTimeGrid.uniform(age_start=0,age_end=120,age_step=5,time_start=1990,time_end=2018,time_step=1)
         >>> d_time = PriorGrid(grid)
         >>> #Set a prior for the whole grid:
-        >>> d_time[:, :].prior = GaussianPrior(0, 0.1)
+        >>> d_time[:, :].prior = Gaussian(0, 0.1)
         >>> #Set a prior for a band of ages
-        >>> d_time[0:15, :].prior = GaussianPrior(1, 0.01)
+        >>> d_time[0:15, :].prior = Gaussian(1, 0.01)
         >>> #Or a single year
-        >>> d_time[:, 1995].prior = GaussianPrior(0, 3)
+        >>> d_time[:, 1995].prior = Gaussian(0, 3)
     """
 
     def __init__(self, grid, hyper_prior=None):

--- a/src/cascade/model/priors.py
+++ b/src/cascade/model/priors.py
@@ -61,7 +61,7 @@ def _validate_nu(nu):
         raise PriorError(f"Nu must be positive: nu={nu}")
 
 
-class UniformPrior(_Prior):
+class Uniform(_Prior):
     density = "uniform"
 
     def __init__(self, lower, upper, mean=None, eta=None, name=None):
@@ -79,7 +79,7 @@ class UniformPrior(_Prior):
         return {"lower": self.lower, "upper": self.upper, "mean": self.mean, "eta": self.eta}
 
 
-class ConstantPrior(_Prior):
+class Constant(_Prior):
     density = "uniform"
 
     def __init__(self, value, name=None):
@@ -90,7 +90,7 @@ class ConstantPrior(_Prior):
         return {"lower": self.value, "upper": self.value, "mean": self.value}
 
 
-class GaussianPrior(_Prior):
+class Gaussian(_Prior):
     density = "gaussian"
 
     def __init__(self, mean, standard_deviation, lower=float("-inf"), upper=float("inf"), eta=None, name=None):
@@ -114,11 +114,11 @@ class GaussianPrior(_Prior):
         }
 
 
-class LaplacePrior(GaussianPrior):
+class Laplace(Gaussian):
     density = "laplace"
 
 
-class StudentsTPrior(_Prior):
+class StudentsT(_Prior):
     density = "students"
 
     def __init__(self, mean, standard_deviation, nu, lower=float("-inf"), upper=float("inf"), eta=None, name=None):
@@ -145,7 +145,7 @@ class StudentsTPrior(_Prior):
         }
 
 
-class LogGaussianPrior(_Prior):
+class LogGaussian(_Prior):
     density = "log_gaussian"
 
     def __init__(self, mean, standard_deviation, eta, lower=float("-inf"), upper=float("inf"), name=None):
@@ -169,11 +169,11 @@ class LogGaussianPrior(_Prior):
         }
 
 
-class LogLaplacePrior(LogGaussianPrior):
+class LogLaplace(LogGaussian):
     density = "log_laplace"
 
 
-class LogStudentsTPrior(_Prior):
+class LogStudentsT(_Prior):
     density = "log_students"
 
     def __init__(self, mean, standard_deviation, nu, eta, lower=float("-inf"), upper=float("inf"), name=None):
@@ -202,7 +202,7 @@ class LogStudentsTPrior(_Prior):
 
 # Useful predefined priors
 
-NO_PRIOR = UniformPrior(float("-inf"), float("inf"), 0)
-ZERO = UniformPrior(0, 0, 0)
-ZERO_TO_ONE = UniformPrior(0, 1, 0.1)
-MINUS_ONE_TO_ONE = UniformPrior(-1, 1, 0)
+NO_PRIOR = Uniform(float("-inf"), float("inf"), 0)
+ZERO = Uniform(0, 0, 0)
+ZERO_TO_ONE = Uniform(0, 1, 0.1)
+MINUS_ONE_TO_ONE = Uniform(-1, 1, 0)

--- a/tests/dismod/test_serialize.py
+++ b/tests/dismod/test_serialize.py
@@ -7,7 +7,7 @@ from pandas.util.testing import assert_frame_equal
 from cascade.core.context import ModelContext
 from cascade.model.grids import PriorGrid, AgeTimeGrid
 from cascade.model.rates import Smooth
-from cascade.model.priors import GaussianPrior, UniformPrior
+from cascade.model.priors import Gaussian, Uniform
 from cascade.dismod.serialize import (
     model_to_dismod_file,
     collect_ages_or_times,
@@ -62,11 +62,11 @@ def base_context(observations, constraints):
     grid = AgeTimeGrid.uniform(age_start=0, age_end=100, age_step=1, time_start=1990, time_end=2018, time_step=5)
 
     d_time = PriorGrid(grid)
-    d_time[:, :].prior = GaussianPrior(0, 0.1, eta=1)
+    d_time[:, :].prior = Gaussian(0, 0.1, eta=1)
     d_age = PriorGrid(grid)
-    d_age[:, :].prior = GaussianPrior(0, 0.1, name="TestPrior")
+    d_age[:, :].prior = Gaussian(0, 0.1, name="TestPrior")
     value = PriorGrid(grid)
-    value[:, :].prior = GaussianPrior(0, 0.1)
+    value[:, :].prior = Gaussian(0, 0.1)
 
     smooth = Smooth(name="iota_smooth")
     smooth.d_time_priors = d_time
@@ -76,8 +76,8 @@ def base_context(observations, constraints):
 
     smooth = Smooth()
     d_time = PriorGrid(grid)
-    d_time[:, :].prior = GaussianPrior(1, 0.1)
-    d_time.hyper_prior = UniformPrior(0, 1, 0.5)
+    d_time[:, :].prior = Gaussian(1, 0.1)
+    d_time.hyper_prior = Uniform(0, 1, 0.5)
     smooth.d_time_priors = d_time
     context.rates.pini.parent_smooth = smooth
 
@@ -114,11 +114,11 @@ def test_development_target(base_context):
 def test_collect_priors(base_context):
     priors = collect_priors(base_context)
     assert priors == {
-        GaussianPrior(0, 0.1, name="TestPrior"),
-        UniformPrior(0, 1, 0.5),
-        GaussianPrior(1, 0.1),
-        GaussianPrior(0, 0.1),
-        GaussianPrior(0, 0.1, eta=1),
+        Gaussian(0, 0.1, name="TestPrior"),
+        Uniform(0, 1, 0.5),
+        Gaussian(1, 0.1),
+        Gaussian(0, 0.1),
+        Gaussian(0, 0.1, eta=1),
     }
 
 

--- a/tests/input_data/configuration/test_builder.py
+++ b/tests/input_data/configuration/test_builder.py
@@ -1,0 +1,95 @@
+import pytest
+
+from cascade.input_data.configuration.form import Configuration
+from cascade.input_data.configuration.builder import (
+    initial_context_from_epiviz,
+    fixed_effects_from_epiviz,
+    integrand_grids_from_epiviz,
+)
+from cascade.model import priors
+
+
+@pytest.fixture
+def base_config():
+    config = Configuration(
+        {
+            "model": {
+                "modelable_entity_id": 12345,
+                "title": "Test Model",
+                "description": "Test Model Description",
+                "drill": "drill",
+                "drill_location": 123,
+                "default_age_grid": "0 10 20 30 40 50 60 70 80",
+                "default_time_grid": "1990 1995 2000 2005 2010",
+            },
+            "gbd_round_id": 5,
+            "random_effect": [],
+            "rate": [
+                {
+                    "rate": 6,
+                    "age_grid": "0 20 40 60 80",
+                    "default": {
+                        "dage": {"density": "gaussian", "mean": 0, "std": 0.1},
+                        "dtime": {"density": "gaussian", "mean": 0, "std": 0.2},
+                        "value": {"density": "gaussian", "mean": 0, "std": 0.3},
+                    },
+                    "detail": [
+                        {
+                            "prior_type": "value",
+                            "age_lower": 20,
+                            "age_upper": 40,
+                            "time_lower": 1995,
+                            "time_upper": 2005,
+                            "density": "students",
+                            "mean": 0,
+                            "std": 0.25,
+                            "nu": 1,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    assert not config.validate_and_normalize()
+    return config
+
+
+def test_initial_context_from_epiviz(base_config):
+    mc = initial_context_from_epiviz(base_config)
+    assert mc.parameters.modelable_entity_id == 12345
+    assert mc.parameters.gbd_round_id == 5
+    assert mc.parameters.location_id == 123
+
+
+def test_fixed_effects_from_epiviz(base_config):
+    mc = initial_context_from_epiviz(base_config)
+    fixed_effects_from_epiviz(mc, base_config)
+    assert all([r.parent_smooth is None for r in [mc.rates.rho, mc.rates.pini, mc.rates.chi, mc.rates.omega]])
+    smooth = mc.rates.iota.parent_smooth
+    assert smooth.d_age_priors.priors == {priors.Gaussian(mean=0, standard_deviation=0.1)}
+    assert smooth.d_time_priors.priors == {priors.Gaussian(mean=0, standard_deviation=0.2)}
+    assert smooth.value_priors.priors == {
+        priors.Gaussian(mean=0, standard_deviation=0.3),
+        priors.StudentsT(mean=0, standard_deviation=0.25, nu=1),
+    }
+    assert set(smooth.grid.ages) == {0.0, 20.0, 40.0, 60.0, 80.0}
+    assert set(smooth.grid.times) == {1990.0, 1995.0, 2000.0, 2005.0, 2010.0}
+
+    for age in smooth.grid.ages:
+        for time in smooth.grid.times:
+            if age in {20.0, 40.0} and time in {1995.0, 2000.0, 2005.0}:
+                assert smooth.value_priors[20, 2000].prior == priors.StudentsT(mean=0, standard_deviation=0.25, nu=1)
+            else:
+                assert smooth.value_priors[0, 1990].prior == priors.Gaussian(mean=0, standard_deviation=0.3)
+
+
+def test_integrand_grids_from_epiviz(base_config):
+    mc = initial_context_from_epiviz(base_config)
+    fixed_effects_from_epiviz(mc, base_config)
+    integrand_grids_from_epiviz(mc, base_config)
+
+    assert all([integrand.grid is None for integrand in mc.outputs.integrands if integrand.name not in ["Sincidence"]])
+    integrand = mc.outputs.integrands.Sincidence
+
+    assert set(integrand.grid.ages) == {0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0}
+    assert set(integrand.grid.times) == {1990.0, 1995.0, 2000.0, 2005.0, 2010.0}

--- a/tests/input_data/configuration/test_form.py
+++ b/tests/input_data/configuration/test_form.py
@@ -5,11 +5,11 @@ from cascade.model import priors
 def test_SmoothingPrior__full_form_validation__success():
     f = SmoothingPrior({"prior_type": "value", "density": "uniform", "min": 0, "max": 10})
     assert not f.validate_and_normalize()
-    assert f.prior_object == priors.UniformPrior(0, 10)
+    assert f.prior_object == priors.Uniform(0, 10)
 
     f = SmoothingPrior({"prior_type": "value", "density": "log_gaussian", "mean": 0, "std": 1, "eta": 1})
     assert not f.validate_and_normalize()
-    assert f.prior_object == priors.LogGaussianPrior(0, 1, 1)
+    assert f.prior_object == priors.LogGaussian(0, 1, 1)
 
 
 def test_SmoothingPrior__full_form_validation__fail():

--- a/tests/input_data/db/test_configuration.py
+++ b/tests/input_data/db/test_configuration.py
@@ -1,0 +1,26 @@
+from cascade.input_data.db.configuration import trim_config, DO_REMOVE
+
+
+def test_trim_config__trivially_empty():
+    assert trim_config({}) is DO_REMOVE
+    assert trim_config([]) is DO_REMOVE
+    assert trim_config(None) is DO_REMOVE
+    assert trim_config("") is DO_REMOVE
+
+
+def test_trim_config__trivially_not_empty():
+    assert trim_config("test") == "test"
+    assert trim_config(["test"]) == ["test"]
+    assert trim_config({"test": "test", "another_test": "another_test"}) == {
+        "test": "test",
+        "another_test": "another_test",
+    }
+
+
+def test_trim_config__nested():
+    assert trim_config({"thing": 10, "other": {"inner": 100, "more_inner": [1, 2, 4]}}) == {
+        "thing": 10,
+        "other": {"inner": 100, "more_inner": [1, 2, 4]},
+    }
+    assert trim_config({"thing": 10, "other": {}}) == {"thing": 10}
+    assert trim_config({"thing": 10, "other": {"bleh": [], "blah": {}}}) == {"thing": 10}

--- a/tests/model/test_grids.py
+++ b/tests/model/test_grids.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 from cascade.model.grids import PriorGrid, AgeTimeGrid, _any_close, GRID_SNAP_DISTANCE, unique_floats
-from cascade.model.priors import GaussianPrior
+from cascade.model.priors import Gaussian
 
 
 @pytest.fixture
@@ -17,58 +17,58 @@ def test_PriorGrid__development_target():
     grid = AgeTimeGrid.uniform(age_start=0, age_end=120, age_step=5, time_start=1990, time_end=2018, time_step=1)
 
     d_time = PriorGrid(grid)
-    d_time[:, :].prior = GaussianPrior(0, 0.1)
+    d_time[:, :].prior = Gaussian(0, 0.1)
 
     # There's a shock in 1995
-    d_time[:, 1995].prior = GaussianPrior(0, 3)
+    d_time[:, 1995].prior = Gaussian(0, 3)
 
     d_age = PriorGrid(grid)
-    d_age[:, :].prior = GaussianPrior(0, 0.1)
+    d_age[:, :].prior = Gaussian(0, 0.1)
 
     # Kids are different
-    d_age[0:15, :].prior = GaussianPrior(1, 0.01)
+    d_age[0:15, :].prior = Gaussian(1, 0.01)
 
     value = PriorGrid(grid)
-    value[:, :].prior = GaussianPrior(20, 1)
+    value[:, :].prior = Gaussian(20, 1)
 
     # The shock in 1995 effects the value too
-    value[:, 1995].prior = GaussianPrior(200, 10)
+    value[:, 1995].prior = Gaussian(200, 10)
 
-    assert value[10, 1995].prior == GaussianPrior(200, 10)
-    assert value[10, 1996].prior == GaussianPrior(20, 1)
+    assert value[10, 1995].prior == Gaussian(200, 10)
+    assert value[10, 1996].prior == Gaussian(20, 1)
 
 
 def test_PriorGrid__point_query(age_time_grid):
     priors = PriorGrid(age_time_grid)
 
-    priors[:, :].prior = GaussianPrior(0, 3)
-    priors[20:40, 2000:2005].prior = GaussianPrior(20, 3)
+    priors[:, :].prior = Gaussian(0, 3)
+    priors[20:40, 2000:2005].prior = Gaussian(20, 3)
 
-    assert priors[10, 1990].prior == GaussianPrior(0, 3)
-    assert priors[10, 2006].prior == GaussianPrior(0, 3)
-    assert priors[50, 2006].prior == GaussianPrior(0, 3)
+    assert priors[10, 1990].prior == Gaussian(0, 3)
+    assert priors[10, 2006].prior == Gaussian(0, 3)
+    assert priors[50, 2006].prior == Gaussian(0, 3)
 
-    assert priors[25, 2001].prior == GaussianPrior(20, 3)
+    assert priors[25, 2001].prior == Gaussian(20, 3)
 
 
 def test_PriorGrid__point_query_with_extreme_values(age_time_grid):
     priors = PriorGrid(age_time_grid)
 
-    priors[:, :].prior = GaussianPrior(0, 3)
+    priors[:, :].prior = Gaussian(0, 3)
 
-    assert priors[min(age_time_grid.ages), 1990].prior == GaussianPrior(0, 3)
-    assert priors[max(age_time_grid.ages), 1990].prior == GaussianPrior(0, 3)
-    assert priors[15, min(age_time_grid.times)].prior == GaussianPrior(0, 3)
-    assert priors[15, max(age_time_grid.times)].prior == GaussianPrior(0, 3)
-    assert priors[min(age_time_grid.ages), min(age_time_grid.times)].prior == GaussianPrior(0, 3)
-    assert priors[max(age_time_grid.ages), max(age_time_grid.times)].prior == GaussianPrior(0, 3)
+    assert priors[min(age_time_grid.ages), 1990].prior == Gaussian(0, 3)
+    assert priors[max(age_time_grid.ages), 1990].prior == Gaussian(0, 3)
+    assert priors[15, min(age_time_grid.times)].prior == Gaussian(0, 3)
+    assert priors[15, max(age_time_grid.times)].prior == Gaussian(0, 3)
+    assert priors[min(age_time_grid.ages), min(age_time_grid.times)].prior == Gaussian(0, 3)
+    assert priors[max(age_time_grid.ages), max(age_time_grid.times)].prior == Gaussian(0, 3)
 
 
 def test_PriorGrid__bad_alignment(age_time_grid):
     priors = PriorGrid(age_time_grid)
 
     with pytest.raises(ValueError):
-        priors[1:12, 1990.4:2001].prior = GaussianPrior(0, 3)
+        priors[1:12, 1990.4:2001].prior = Gaussian(0, 3)
 
 
 def test_PriorGrid__wrong_dimensions(age_time_grid):

--- a/tests/model/test_priors.py
+++ b/tests/model/test_priors.py
@@ -1,71 +1,71 @@
 import pytest
 
 from cascade.model.priors import (
-    GaussianPrior,
-    UniformPrior,
-    LaplacePrior,
-    StudentsTPrior,
-    LogGaussianPrior,
-    LogLaplacePrior,
-    LogStudentsTPrior,
+    Gaussian,
+    Uniform,
+    Laplace,
+    StudentsT,
+    LogGaussian,
+    LogLaplace,
+    LogStudentsT,
     PriorError,
 )
 
 
 def test_happy_construction():
-    UniformPrior(-1, 1, 0, name="test")
-    UniformPrior(-1, 1, 0, 0.5, name="test")
-    GaussianPrior(0, 1, -10, 10, name="test2")
-    GaussianPrior(0, 1, -10, 10, 0.5, name="test2")
-    LaplacePrior(0, 1, -10, 10, name="test3")
-    LaplacePrior(0, 1, -10, 10, 0.5, name="test3")
-    StudentsTPrior(0, 1, 0.5, -10, 10, name="test4")
-    LogGaussianPrior(0, 1, 0.5, -10, 10, name="test5")
-    LogLaplacePrior(0, 1, 0.5, -10, 10, name="test6")
-    LogStudentsTPrior(0, 1, 0.5, 0.5, -10, 10, name="test7")
+    Uniform(-1, 1, 0, name="test")
+    Uniform(-1, 1, 0, 0.5, name="test")
+    Gaussian(0, 1, -10, 10, name="test2")
+    Gaussian(0, 1, -10, 10, 0.5, name="test2")
+    Laplace(0, 1, -10, 10, name="test3")
+    Laplace(0, 1, -10, 10, 0.5, name="test3")
+    StudentsT(0, 1, 0.5, -10, 10, name="test4")
+    LogGaussian(0, 1, 0.5, -10, 10, name="test5")
+    LogLaplace(0, 1, 0.5, -10, 10, name="test6")
+    LogStudentsT(0, 1, 0.5, 0.5, -10, 10, name="test7")
 
 
 def test_prior_equality():
-    a = GaussianPrior(0, 1)
-    b = GaussianPrior(0, 1)
+    a = Gaussian(0, 1)
+    b = Gaussian(0, 1)
     assert a == b
 
-    a = GaussianPrior(0, 1, -1, 1)
-    b = GaussianPrior(0, 1, -1, 1)
+    a = Gaussian(0, 1, -1, 1)
+    b = Gaussian(0, 1, -1, 1)
     assert a == b
 
-    a = UniformPrior(0, 10)
-    b = UniformPrior(0, 10)
+    a = Uniform(0, 10)
+    b = Uniform(0, 10)
     assert a == b
 
-    a = UniformPrior(0, 10, name="test_prior")
-    b = UniformPrior(0, 10, name="test_prior")
+    a = Uniform(0, 10, name="test_prior")
+    b = Uniform(0, 10, name="test_prior")
     assert a == b
 
 
 def test_prior_nonequality():
-    a = GaussianPrior(0, 1)
-    b = GaussianPrior(1, 1)
+    a = Gaussian(0, 1)
+    b = Gaussian(1, 1)
     assert a != b
 
-    a = UniformPrior(0, 1)
-    b = UniformPrior(-1, 0)
+    a = Uniform(0, 1)
+    b = Uniform(-1, 0)
     assert a != b
 
-    a = GaussianPrior(0, 1, name="test_prior")
-    b = GaussianPrior(0, 1, name="other_test_prior")
+    a = Gaussian(0, 1, name="test_prior")
+    b = Gaussian(0, 1, name="other_test_prior")
     assert a != b
 
-    a = GaussianPrior(0, 1)
-    b = UniformPrior(0, 1)
+    a = Gaussian(0, 1)
+    b = Uniform(0, 1)
     assert a != b
 
 
 def test_prior_sort():
     priors = [
-        UniformPrior(lower=1e-10, upper=1, mean=5e-5, name="iota"),
-        GaussianPrior(0, 1, name="other_test_prior"),
-        UniformPrior(0, 1),
+        Uniform(lower=1e-10, upper=1, mean=5e-5, name="iota"),
+        Gaussian(0, 1, name="other_test_prior"),
+        Uniform(0, 1),
     ]
 
     # NOTE: This is a weak test of actual sorting behavior however all I
@@ -75,26 +75,31 @@ def test_prior_sort():
 
 
 def test_prior_hashing():
-    s = {GaussianPrior(0, 1), UniformPrior(0, 1), GaussianPrior(0, 1), UniformPrior(0, 2), UniformPrior(0, 1)}
+    s = {Gaussian(0, 1), Uniform(0, 1), Gaussian(0, 1), Uniform(0, 2), Uniform(0, 1)}
 
     assert len(s) == 3
-    assert GaussianPrior(0, 1) in s
-    assert UniformPrior(0, 10) not in s
+    assert Gaussian(0, 1) in s
+    assert Uniform(0, 10) not in s
+
+
+def test_prior_hashing__near_miss():
+    assert hash(Gaussian(0, 1.0000000000000001)) == hash(Gaussian(0, 1))
+    assert hash(Gaussian(0, 1.000000000000001)) != hash(Gaussian(0, 1))
 
 
 def test_bounds_check():
     with pytest.raises(PriorError) as excinfo:
-        UniformPrior(0, -1, 1)
+        Uniform(0, -1, 1)
     assert "Bounds are inconsistent" in str(excinfo.value)
 
 
 def test_validate_standard_deviation():
     with pytest.raises(PriorError) as excinfo:
-        GaussianPrior(0, -1)
+        Gaussian(0, -1)
     assert "must be positive" in str(excinfo.value)
 
 
 def test_validate_nu():
     with pytest.raises(PriorError) as excinfo:
-        StudentsTPrior(0, 1, -1)
+        StudentsT(0, 1, -1)
     assert "must be positive" in str(excinfo.value)


### PR DESCRIPTION
This is a follow up to https://github.com/ihmeuw/cascade/pull/41 and is much simpler. It provides some functions for loading EpiViz settings into the Configuration form defined in the last PR and transforming that into an internal model representation but only covers a few concepts. There's an example executable (examples/simple_load_from_epiviz.py) which builds a dismod database with basic settings and smoothing grids for a model named by either modelable entity id or model version id.