### PR TITLE
Feature/acceptance test

### DIFF
--- a/acceptance/test_smoke.py
+++ b/acceptance/test_smoke.py
@@ -1,0 +1,18 @@
+"""
+Ensure that applications are installed and runnable.
+"""
+from subprocess import run
+
+
+def test_dismod_smoke():
+    """
+    Tests whether Dismod can be found from the dmdismod script.
+    """
+    run("dmdismod --help".split(), check=True)
+
+
+def test_csv2db_smoke():
+    """
+    Tests whether dmcsv2db is installed into the current environment.
+    """
+    run("dmcsv2db --help".split(), check=True)

--- a/src/cascade/input_data/db/__init__.py
+++ b/src/cascade/input_data/db/__init__.py
@@ -1,12 +1,4 @@
-try:
-    import db_queries
-except ImportError:
-
-    class DummyDBQueries:
-        def __getattr__(self, name):
-            raise ImportError(f"Required package db_queries not found")
-
-    db_queries = DummyDBQueries()
+from cascade.input_data.db import module_proxy
 
 AGE_GROUP_SET_ID = 12
 
@@ -15,3 +7,11 @@ GBD_ROUND_ID = 5
 METRIC_IDS = {"per_capita_rate": 3}
 
 MEASURE_IDS = {"deaths": 1}
+
+db_queries = module_proxy.ModuleProxy("db_queries")
+db_tools = module_proxy.ModuleProxy("db_tools")
+save_results = module_proxy.ModuleProxy("save_results")
+
+
+def disable_databases():
+    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = True

--- a/src/cascade/input_data/db/__init__.py
+++ b/src/cascade/input_data/db/__init__.py
@@ -11,7 +11,3 @@ MEASURE_IDS = {"deaths": 1}
 db_queries = module_proxy.ModuleProxy("db_queries")
 db_tools = module_proxy.ModuleProxy("db_tools")
 save_results = module_proxy.ModuleProxy("save_results")
-
-
-def disable_databases():
-    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = True

--- a/src/cascade/input_data/db/module_proxy.py
+++ b/src/cascade/input_data/db/module_proxy.py
@@ -1,0 +1,39 @@
+"""
+This is a proxy to the database modules.
+"""
+import importlib
+
+
+BLOCK_SHARED_FUNCTION_ACCESS = False
+"""
+Used to control access to the testing environment. You can't load this
+with from <module> import BLOCK_SHARED_FUNCTION_ACCESS. You have to
+modify the value as ``module_proxy.BLOCK_SHARED_FUNCTION_ACCESS``.
+"""
+
+
+class ModuleProxy:
+    """
+    This class acts like a module. It's meant to be imported into an init.
+    This exists in order to actively turn off modules during testing.
+    """
+    def __init__(self, module_name):
+        if not isinstance(module_name, str):
+            raise ValueError(f"This accepts a module name, not the module itself.")
+
+        self.name = module_name
+        try:
+            self._module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            self._module = None
+
+    def __getattr__(self, name):
+        if BLOCK_SHARED_FUNCTION_ACCESS:
+            raise ModuleNotFoundError(
+                f"Illegal access to module {self.name}. Are you trying to use "
+                f"the shared functions in a unit test?")
+
+        return getattr(self._module, name)
+
+    def __dir__(self):
+        return dir(self._module)

--- a/tests/input_data/db/test_module_proxy.py
+++ b/tests/input_data/db/test_module_proxy.py
@@ -30,6 +30,15 @@ def test_disable_proxy(save_access):
 
 
 def test_disable_all(save_access):
-    db.disable_databases()
+    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = True
     with pytest.raises(ModuleNotFoundError):
         db.db_queries.get_cause_metadata("the values", "don't matter")
+
+
+def test_ihme_access(ihme_db):
+    """
+    This test should be skipped normally and execute (and pass)
+    when the --ihme-db flag is used.
+    """
+    df = db.db_queries.get_age_metadata(age_group_set_id=12, gbd_round_id=5)
+    assert not df.empty

--- a/tests/input_data/db/test_module_proxy.py
+++ b/tests/input_data/db/test_module_proxy.py
@@ -1,0 +1,35 @@
+import cascade.input_data.db as db
+from cascade.input_data.db.module_proxy import ModuleProxy
+from cascade.input_data.db import module_proxy
+
+import pytest
+
+
+@pytest.fixture
+def save_access():
+    """Testing will use this value, so we save whatever was
+    set in order not to mess with testing."""
+    saved = module_proxy.BLOCK_SHARED_FUNCTION_ACCESS
+    yield module_proxy.BLOCK_SHARED_FUNCTION_ACCESS
+    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = saved
+
+
+def test_any_proxy(save_access):
+    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = False
+    m = ModuleProxy("math")
+    assert m.floor(3.2) == 3.0
+
+
+def test_disable_proxy(save_access):
+    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = False
+    m = ModuleProxy("pathlib")
+    m.Path("/ihme/somewhere")
+    module_proxy.BLOCK_SHARED_FUNCTION_ACCESS = True
+    with pytest.raises(ModuleNotFoundError):
+        m.Path("/ihme/code")
+
+
+def test_disable_all(save_access):
+    db.disable_databases()
+    with pytest.raises(ModuleNotFoundError):
+        db.db_queries.get_cause_metadata("the values", "don't matter")

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py36
 [pytest]
 xfail_strict = true
+testpaths = tests
 [testenv]
 extras=testing
 commands=py.test


### PR DESCRIPTION
The goal is to define tests according to when we run them:

1. Default is not to use IHME resources or do long tests.
2. The `--ihme-db` flag turns on availability of IHME databases. This is for laptop tests within VPN.
3. To run acceptance tests, go to the acceptance directory and run pytest.

What's complicated: In order to use IHME databases, you now have to include a fixture called "ihme_db". If you don't, then the tests will fail.
