### PR TITLE
feature/DISMODAT-286-meid-quota-documentation

### DIFF
--- a/docs/dev/dbsync.rst
+++ b/docs/dev/dbsync.rst
@@ -3,21 +3,21 @@
 Auto Sync of DB tables so we can run MR and AT in parallel
 ===========================================================
 
-Scripts run daily on Jenkins to sync 12 tables from modeling-epi-db with epiat-db-p01
-and epi-db-d01.  The 12 tables are:
+Scripts run daily on Jenkins to sync 12 tables from ``modeling-epi-db`` to ``epiat-db-p01``
+and ``epi-db-d01``.  The 12 tables are:
 
-* epi.modelable_entity
-* epi.modelable_entity_cause
-* epi.modelable_entity_metadata
-* epi.modelable_entity_metadata_type
-* epi.modelable_entity_note
-* epi.modelable_entity_quota
-* epi.modelable_entity_rei
-* epi.modelable_entity_set
-* epi.modelable_entity_set_version
-* epi.modelable_entity_set_version_active
-* epi.modelable_entity_type
-* epi.study_covariate
+* ``epi.modelable_entity``
+* ``epi.modelable_entity_cause``
+* ``epi.modelable_entity_metadata``
+* ``epi.modelable_entity_metadata_type``
+* ``epi.modelable_entity_note``
+* ``epi.modelable_entity_quota``
+* ``epi.modelable_entity_rei``
+* ``epi.modelable_entity_set``
+* ``epi.modelable_entity_set_version``
+* ``epi.modelable_entity_set_version_active``
+* ``epi.modelable_entity_type``
+* ``epi.study_covariate``
   
 If there are no changes, nothing is replicated.
 
@@ -26,9 +26,9 @@ The sync can be run manually, if desired, by:
 
 #. logging into Jenkins: https://centralcompdb-jenkins.ihme.washington.edu/
 
-#. clicking on the job: Epi_Refresh_From_modeling-epi-db_modelable_entity_study_covariate
+#. clicking on the job: **Epi_Refresh_From_modeling-epi-db_modelable_entity_study_covariate**
 
-#. clicking on Build Now
+#. clicking on: **Build Now**
 
 
 To see the result of the run: 
@@ -38,12 +38,11 @@ To see the result of the run:
 #. click on Console Output
 
 
-The scripts are located at:
-
+The scripts are located here:
 https://stash.ihme.washington.edu/projects/IHMEDB/repos/epi/browse/shell_scripts
 
 and they are: 
 
-* epi-pt-table-epi-db-d01-run.sh	DD-1091, DD-1095
-* epi-pt-table-epiat-run.sh	        DD-1091, DD-1095	
-* epi-pt-table-sync-list-tables.sh	DD-1091, DD-1095
+* ``epi-pt-table-epi-db-d01-run.sh``	DD-1091, DD-1095
+* ``epi-pt-table-epiat-run.sh``	        DD-1091, DD-1095	
+* ``epi-pt-table-sync-list-tables.sh``	DD-1091, DD-1095

--- a/docs/dev/dbsync.rst
+++ b/docs/dev/dbsync.rst
@@ -1,0 +1,49 @@
+.. _db-autosync:
+
+Auto Sync of DB tables so we can run MR and AT in parallel
+===========================================================
+
+Scripts run daily on Jenkins to sync 12 tables from modeling-epi-db with epiat-db-p01
+and epi-db-d01.  The 12 tables are:
+
+* epi.modelable_entity
+* epi.modelable_entity_cause
+* epi.modelable_entity_metadata
+* epi.modelable_entity_metadata_type
+* epi.modelable_entity_note
+* epi.modelable_entity_quota
+* epi.modelable_entity_rei
+* epi.modelable_entity_set
+* epi.modelable_entity_set_version
+* epi.modelable_entity_set_version_active
+* epi.modelable_entity_type
+* epi.study_covariate
+  
+If there are no changes, nothing is replicated.
+
+
+The sync can be run manually, if desired, by: 
+
+#. logging into Jenkins: https://centralcompdb-jenkins.ihme.washington.edu/
+
+#. clicking on the job: Epi_Refresh_From_modeling-epi-db_modelable_entity_study_covariate
+
+#. clicking on Build Now
+
+
+To see the result of the run: 
+
+#. click on the build link
+
+#. click on Console Output
+
+
+The scripts are located at:
+
+https://stash.ihme.washington.edu/projects/IHMEDB/repos/epi/browse/shell_scripts
+
+and they are: 
+
+* epi-pt-table-epi-db-d01-run.sh	DD-1091, DD-1095
+* epi-pt-table-epiat-run.sh	        DD-1091, DD-1095	
+* epi-pt-table-sync-list-tables.sh	DD-1091, DD-1095

--- a/docs/dev/dev.rst
+++ b/docs/dev/dev.rst
@@ -5,4 +5,6 @@ Developer Manual
 .. toctree::
    :maxdepth: 2
 
+   dbsync
+   meid_quota
    testing

--- a/docs/dev/meid_quota.rst
+++ b/docs/dev/meid_quota.rst
@@ -3,23 +3,19 @@
 Update the modelable_entity_id quota in the db
 ===============================================
 
-By default the modelable_entity_id can have at most 10 models defined.
-
-This cap is stored in the db table epi.modelable_entity_quota as quota.
-
-The quota can be updated by calling the stored procedure, epi_model_quota_add.
-
-As an example, this SQL CALL statement will change the quota value for meid=1744 to 20.
+By default the ``modelable_entity_id`` can have at most 10 models defined.
+This cap is stored in the db table ``epi.modelable_entity_quota`` as ``quota``.
+The quota can be updated by calling the stored procedure, ``epi_model_quota_add``.
+As an example, this SQL CALL statement will change the quota value for meid=1744 to 20::
 
     call epi.epi_model_quota_add(1744, 20, 'at_cascade');
 
-The user 'at_cascade' must have "execute" permission on the stored procedure.
-
-The db team has given this permission to user at_cascade: 
+The user ``at_cascade`` must have "execute" permission on the stored procedure.
+The db team has given this permission to user ``at_cascade``:: 
 
     GRANT EXECUTE ON PROCEDURE `epi`.`epi_model_quota_add` TO 'at_cascade'@'%';  
 
-in both of the dismod_at db's, dev and prod: epi-db-d01 and epiat-db-p01
+in both of the dismod_at db's, dev and prod: ``epi-db-d01`` and ``epiat-db-p01``
 
 
 

--- a/docs/dev/meid_quota.rst
+++ b/docs/dev/meid_quota.rst
@@ -1,0 +1,25 @@
+.. _meid-quota:
+
+Update the modelable_entity_id quota in the db
+===============================================
+
+By default the modelable_entity_id can have at most 10 models defined.
+
+This cap is stored in the db table epi.modelable_entity_quota as quota.
+
+The quota can be updated by calling the stored procedure, epi_model_quota_add.
+
+As an example, this SQL CALL statement will change the quota value for meid=1744 to 20.
+
+    call epi.epi_model_quota_add(1744, 20, 'at_cascade');
+
+The user 'at_cascade' must have "execute" permission on the stored procedure.
+
+The db team has given this permission to user at_cascade: 
+
+    GRANT EXECUTE ON PROCEDURE `epi`.`epi_model_quota_add` TO 'at_cascade'@'%';  
+
+in both of the dismod_at db's, dev and prod: epi-db-d01 and epiat-db-p01
+
+
+


### PR DESCRIPTION
1. documented the process for updating the quota on number of models defined for an meid
2. we have permissions to update this quota in both the dismod_at dev and prod db's
3. moved over the documentation from cascade_at for the "db auto sync" (i.e. previous work w/Tatiana)

