### PR TITLE
Feature/dismodat 295 mr and at results plots to csv

### DIFF
--- a/docs/user/dmsr2csv.rst
+++ b/docs/user/dmsr2csv.rst
@@ -37,12 +37,12 @@ To run the script on the cluster:
 
 2. Run the script and supply values for <x>, <y>, and <d>:: 
 
-    cluster> dmsr2csv --at_mvid=<x> --ode_mvid=<y> --output_dir=<d>     
+    cluster> dmsr2csv --at-mvid=<x> --ode-mvid=<y> --output-dir=<d>     
 
 
 An example call to ``dmsr2csv`` is::
 
-    dmsr2csv --at_mvid=265844 --ode_mvid=102680 --output_dir=/ihme/code/someusername/somedir
+    dmsr2csv --at-mvid=265844 --ode-mvid=102680 --output-dir=/ihme/code/someusername/somedir
 
 Two csv files will be written to ``/ihme/code/someusername/somedir``::
 

--- a/docs/user/dmsr2csv.rst
+++ b/docs/user/dmsr2csv.rst
@@ -13,25 +13,25 @@ or if no ``model_version_id`` is provided, an empty dataframe will be retrieved 
 a csv file with no rows of data will be written.  
 
 The output is a csv file for an AT model and a csv file for an ODE model.
-These files have the names: at_<mvid> and ode_<mvid>, where <mvid> stands for the 
-model_version_id provided for each model type.
+These files have the names: ``at_<mvid>.csv`` and ``ode_<mvid>.csv``, where <mvid> 
+stands for the model_version_id provided for each model type.
 
-To run the script on the cluster::
+To run the script on the cluster:
 
-1. Activate the current cascade environment
+1. Activate the current cascade environment::
 
-cluster> source /ihme/code/dismod_at/env/current/bin/activate
+    cluster> source /ihme/code/dismod_at/env/current/bin/activate
 
-2. Run the script and supply values for <x>, <y>, and <d> 
+2. Run the script and supply values for <x>, <y>, and <d>:: 
 
-cluster> dmsr2csv --at_mvid=<x> --ode_mvid=<y> --output_dir=<d>     
+    cluster> dmsr2csv --at_mvid=<x> --ode_mvid=<y> --output_dir=<d>     
 
 
 An example call to ``dmsr2csv`` is::
 
     dmsr2csv --at_mvid=265844 --ode_mvid=102680 --output_dir=/ihme/code/someusername/somedir
 
-Two csv files will be written to /ihme/code/someusername/somedir::
+Two csv files will be written to ``/ihme/code/someusername/somedir``::
 
     at_265844.csv and ode_102680.csv
 

--- a/docs/user/dmsr2csv.rst
+++ b/docs/user/dmsr2csv.rst
@@ -1,0 +1,40 @@
+DMSR2CSV Tool
+=============
+
+This is a script that retrieves model results for Dismod AT and ODE models
+and writes it as a csv file for each model type.  The data is retrieved from
+the ``epi.model_estimate_fit`` table.  The database used for AT is ``dismod-at-dev``
+and for ODE is ``epi``.
+
+The input required is a ``model_version_id`` for each model type.  Optionally, an
+output directory can be specified for the csv files, otherwise, they will be
+written to the current directory.  If an invalid ``model_version_id`` is provided
+or if no ``model_version_id`` is provided, an empty dataframe will be retrieved and 
+a csv file with no rows of data will be written.  
+
+The output is a csv file for an AT model and a csv file for an ODE model.
+These files have the names: at_<mvid> and ode_<mvid>, where <mvid> stands for the 
+model_version_id provided for each model type.
+
+To run the script on the cluster::
+
+1. Activate the current cascade environment
+
+cluster> source /ihme/code/dismod_at/env/current/bin/activate
+
+2. Run the script and supply values for <x>, <y>, and <d> 
+
+cluster> dmsr2csv --at_mvid=<x> --ode_mvid=<y> --output_dir=<d>     
+
+
+An example call to ``dmsr2csv`` is::
+
+    dmsr2csv --at_mvid=265844 --ode_mvid=102680 --output_dir=/ihme/code/someusername/somedir
+
+Two csv files will be written to /ihme/code/someusername/somedir::
+
+    at_265844.csv and ode_102680.csv
+
+
+
+

--- a/docs/user/dmsr2csv.rst
+++ b/docs/user/dmsr2csv.rst
@@ -14,7 +14,20 @@ a csv file with no rows of data will be written.
 
 The output is a csv file for an AT model and a csv file for an ODE model.
 These files have the names: ``at_<mvid>.csv`` and ``ode_<mvid>.csv``, where <mvid> 
-stands for the model_version_id provided for each model type.
+stands for the model_version_id provided for each model type.  
+
+The columns in the output files are the same as those in the ``epi.model_estimate_fit`` 
+table:
+
+ * model_version_id
+ * year_id
+ * location_id
+ * sex_id
+ * age_group_id
+ * measure_id
+ * mean
+ * upper
+ * lower
 
 To run the script on the cluster:
 

--- a/docs/user/user.rst
+++ b/docs/user/user.rst
@@ -9,3 +9,4 @@ User Manual
    dmcsv2db
    dismodat
    covariates
+   dmsr2csv

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
             ["dmchat=cascade.executor.chatter:chatter"],
             ["dmdummy=cascade.executor.chatter:dismod_dummy"],
             ["dmcsv2db=cascade.executor.no_covariate_main:entry"],
+            ["dmsr2csv=cascade.executor.model_results_main:entry"],
         ]
     },
     scripts=["scripts/dmdismod", "scripts/dmdismodpy"],

--- a/src/cascade/executor/model_results_main.py
+++ b/src/cascade/executor/model_results_main.py
@@ -69,9 +69,9 @@ def entry():
     similarly if no ode_mvid is provided, an empty ode_None.csv is written.
     """
     parser = ArgumentParser("Writes two csv files, one for Dismod AT results and one for Dismod ODE results.")
-    parser.add_argument("--at_mvid", help="model_version_id for AT results")
-    parser.add_argument("--ode_mvid", help="model_version_id for ODE results")
-    parser.add_argument("--output_dir", default=".", help="output directory for csv files")
+    parser.add_argument("--at-mvid", help="model_version_id for AT results")
+    parser.add_argument("--ode-mvid", help="model_version_id for ODE results")
+    parser.add_argument("--output-dir", default=".", help="output directory for csv files")
     parser.add_argument("-v", help="increase debugging verbosity", action="store_true")
     args, _ = parser.parse_known_args()
     if args.v:

--- a/src/cascade/executor/model_results_main.py
+++ b/src/cascade/executor/model_results_main.py
@@ -1,0 +1,86 @@
+"""This module contributes to being able to compare results from Dismod ODE and Dismod AT.
+"""
+from argparse import ArgumentParser
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from cascade.core.db import connection
+
+
+CODELOG = logging.getLogger(__name__)
+
+
+def _get_model_results(model_version_id, model_type):
+    """Downloads the model results data for a Dismod model of type ODE or AT.
+
+    If saves_results data does not exist for model_version_id, an empty dataframe
+    is returned.  This includes the case of a user supplying text, such as 'three',
+    as a model_version_id.
+
+    Args:
+        model_version_id (int): identifies the data to retrieve
+        model_type (str): identifies the Dismod model type, AT or ODE
+
+    Returns:
+        pandas.DataFrame: containing all columns in the "save results" upload table
+    """
+
+    if model_type.upper() == "AT":
+        database = "dismod-at-dev"
+    elif model_type.upper() == "ODE":
+        database = "epi"
+    else:
+        raise ValueError(f"model must be of type 'ODE' or 'AT', not {model_type}")
+
+    table = "epi.model_estimate_fit"
+
+    query = f"""
+    SELECT * FROM {table}
+    WHERE
+        model_version_id = %(model_version_id)s
+    """
+
+    with connection(database=database) as c:
+        model_results_data = pd.read_sql(query, c, params={"model_version_id": model_version_id})
+        CODELOG.debug(f"""Downloaded {len(model_results_data)} lines of dismod {model_type}
+                      data for model_version_id {model_version_id} from '{database}'""")
+
+    return model_results_data
+
+
+def _write_model_results(model_results, model_version_id, model_type, output_dir):
+    """ Writes the model_results dataframe as a csv file to the output dir.
+    """
+    file_name = Path(output_dir) / f"{model_type.lower()}_{model_version_id}.csv"
+    model_results.to_csv(file_name)
+
+
+def entry():
+    """This is the entry that setuptools turns into an installed program.
+
+    If the user does not provide an at_mvid, an empty dataframe is written as at_None.csv;
+    similarly if no ode_mvid is provided, an empty ode_None.csv is written.
+    """
+    parser = ArgumentParser("Writes two csv files, one for dismod AT results and one for dismod ODE results.")
+    parser.add_argument("--at_mvid", help="model_version_id for AT results")
+    parser.add_argument("--ode_mvid", help="model_version_id for ODE results")
+    parser.add_argument("--output_dir", default=".", help="output directory for csv files")
+    parser.add_argument("-v", help="increase debugging verbosity", action="store_true")
+    args, _ = parser.parse_known_args()
+    if args.v:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logging.basicConfig(level=log_level)
+
+    at_results = _get_model_results(args.at_mvid, "AT")
+    ode_results = _get_model_results(args.ode_mvid, "ODE")
+
+    _write_model_results(at_results, args.at_mvid, "AT", args.output_dir)
+    _write_model_results(ode_results, args.ode_mvid, "ODE", args.output_dir)
+
+
+if __name__ == "__main__":
+    entry()

--- a/tests/executor/test_model_results_main.py
+++ b/tests/executor/test_model_results_main.py
@@ -1,22 +1,47 @@
+import pandas as pd
 import pytest
 
-from cascade.executor.model_results_main import _get_model_results 
+from cascade.executor.model_results_main import _get_model_results
 
 
-
+@pytest.mark.skip
 def test_get_model_results_inputs_ok():
-"""ode_mvid=102680 has 238836 rows, at_mvid=265844 has 5850 rows"""
+    """at_mvid=265844 has 5850 rows, ode_mvid=102680 has 238836 rows
+    """
+    results_columns = ['model_version_id', 'year_id', 'location_id', 'sex_id',
+                       'age_group_id', 'measure_id', 'mean', 'upper', 'lower']
+
+    ode_model_version_id = 102680
+    ode_model_type = "ODE"
+    ode_results = _get_model_results(ode_model_version_id, ode_model_type)
+
+    assert ode_results.columns == results_columns
+
+    at_model_version_id = 265844
+    at_model_type = "AT"
+    at_results = _get_model_results(at_model_version_id, at_model_type)
+
+    assert at_results.columns == results_columns
+
+    at_row_index_8 = pd.Series([265844, 1990, 90, 1, 2, 16, 0.16196, 0.16196, 0.16196])
+
+    pd.testing.assert_series_equal(at_results.iloc[8], at_row_index_8)
 
 
 def test_get_model_results_bad_model_type():
-"""Expect an exception if model_type is not AT or ODE"""
+    """Expect an exception if model_type is not AT or ODE"""
+    with pytest.raises(ValueError):
+        model_version_id = 265844
+        model_type = "NOT_AT_OR_ODE"
+        _get_model_results(model_version_id, model_type)
 
 
+@pytest.mark.skip
 def test_get_model_results_bad_model_version_id():
-"""Expect an empty dataframe if model_version_id is not in the database"""
+    """Expect an empty dataframe if model_version_id is not in the database"""
 
+    at_model_version_id = 1
+    at_model_type = "AT"
+    at_results = _get_model_results(at_model_version_id, at_model_type)
 
-
-def test_entry():
-
-
+    assert at_results.empty

--- a/tests/executor/test_model_results_main.py
+++ b/tests/executor/test_model_results_main.py
@@ -1,0 +1,22 @@
+import pytest
+
+from cascade.executor.model_results_main import _get_model_results 
+
+
+
+def test_get_model_results_inputs_ok():
+"""ode_mvid=102680 has 238836 rows, at_mvid=265844 has 5850 rows"""
+
+
+def test_get_model_results_bad_model_type():
+"""Expect an exception if model_type is not AT or ODE"""
+
+
+def test_get_model_results_bad_model_version_id():
+"""Expect an empty dataframe if model_version_id is not in the database"""
+
+
+
+def test_entry():
+
+

--- a/tests/executor/test_model_results_main.py
+++ b/tests/executor/test_model_results_main.py
@@ -4,8 +4,7 @@ import pytest
 from cascade.executor.model_results_main import _get_model_results
 
 
-@pytest.mark.skip
-def test_get_model_results_inputs_ok():
+def test_get_model_results_inputs_ok(ihme):
     """at_mvid=265844 has 5850 rows, ode_mvid=102680 has 238836 rows
     """
     results_columns = ['model_version_id', 'year_id', 'location_id', 'sex_id',
@@ -15,17 +14,19 @@ def test_get_model_results_inputs_ok():
     ode_model_type = "ODE"
     ode_results = _get_model_results(ode_model_version_id, ode_model_type)
 
-    assert ode_results.columns == results_columns
+    assert set(ode_results.columns) == set(results_columns)
 
     at_model_version_id = 265844
     at_model_type = "AT"
     at_results = _get_model_results(at_model_version_id, at_model_type)
 
-    assert at_results.columns == results_columns
+    assert set(at_results.columns) == set(results_columns)
 
-    at_row_index_8 = pd.Series([265844, 1990, 90, 1, 2, 16, 0.16196, 0.16196, 0.16196])
+    at_row_index_8 = pd.Series([265844, 1990, 90, 1, 2, 16, 0.161961, 0.161961, 0.161961])
+    at_row_index_8.index = at_results.columns
 
-    pd.testing.assert_series_equal(at_results.iloc[8], at_row_index_8)
+    pd.testing.assert_series_equal(at_results.iloc[8], at_row_index_8,
+                                   check_exact=False, check_names=False)
 
 
 def test_get_model_results_bad_model_type():
@@ -36,8 +37,7 @@ def test_get_model_results_bad_model_type():
         _get_model_results(model_version_id, model_type)
 
 
-@pytest.mark.skip
-def test_get_model_results_bad_model_version_id():
+def test_get_model_results_bad_model_version_id(ihme):
     """Expect an empty dataframe if model_version_id is not in the database"""
 
     at_model_version_id = 1

--- a/tests/executor/test_model_results_main.py
+++ b/tests/executor/test_model_results_main.py
@@ -29,7 +29,7 @@ def test_get_model_results_inputs_ok(ihme):
                                    check_exact=False, check_names=False)
 
 
-def test_get_model_results_bad_model_type():
+def test_get_model_results_bad_model_type(ihme):
     """Expect an exception if model_type is not AT or ODE"""
     with pytest.raises(ValueError):
         model_version_id = 265844


### PR DESCRIPTION
This creates an entry point for modelers to use to retrieve AT and ODE data and have it written out as csv files.  

docs: I built them and checked them in a browser.  Modelers would follow this page to use the tool.

tests: I don't know how to test entry() which relies on command line args.  I wrote three tests for _get_model_results, and am skipping two of them because they use ezfuncs.  I am stopping at this point, so you'all can take a look.  I did test using model_results_main.py by hand.  I get data back, and I can output it to the current directory or to a specified directory. 