### PR TITLE
needed to validate settings in order to complete building them

### DIFF
--- a/src/cascade/input_data/configuration/builder.py
+++ b/src/cascade/input_data/configuration/builder.py
@@ -145,7 +145,7 @@ def create_covariate_multipliers(context, configuration, column_map):
 
         smooth = make_smooth(configuration, mul_cov_config, name_prefix=target_dismod_name)
         try:
-            covariate_obj = column_id_func(mul_cov_config.country_covariate_id, mul_cov_config.transformation)
+            covariate_obj = column_map[(cov_id, mul_cov_config.transformation)]
         except KeyError:
             raise RuntimeError(f"A covariate id and its transformation weren't found: "
                                f"{cov_id}, with transform {mul_cov_config.transformation}.")

--- a/tests/input_data/configuration/test_builder.py
+++ b/tests/input_data/configuration/test_builder.py
@@ -173,6 +173,7 @@ def test_covariates_from_settings_logic(base_config, ihme):
         ],
     }
     configuration.country_covariate = [start]
+    configuration.validate_and_normalize()
     assert configuration.model.default_time_grid
     ec = make_execution_context(gbd_round_id=5)
     assert ec.parameters.gbd_round_id == 5


### PR DESCRIPTION
One of the ihme-only tests broke when I merged both PRs. The settings need to be validated in order for them to have a consistent state. In particular, a prior was missing its prior_object, which caused failure in the code.