### PR TITLE
Feature/travis update version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ git:
   depth: 3
 language: python
 python:
-    - "3.6"
     - "3.7-dev"
 install:
     - pip install tox flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+sudo: false
 language: python
 python:
     - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
     - "3.6"
 install:
-    - pip install tox
+    - pip install tox flake8
 script:
     - flake8 src
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 dist: trusty
-sudo: true
+sudo: false
 git:
   depth: 3
 language: python
 python:
-    - "3.7-dev"
+    - "3.6"
 install:
     - pip install tox flake8
-    - sudo apt-get install libhdf5-dev
 script:
     - flake8 src
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 dist: trusty
 sudo: false
+git:
+  depth: 3
 language: python
 python:
     - "3.6"
+    - "3.7-dev"
 install:
     - pip install tox flake8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
+dist: trusty
 language: python
 python:
     - "3.6"
-    - "3.7"
-install: 
+install:
     - pip install tox
-    - pip install -r docs/requirements.txt
 script:
     - flake8 src
     - tox
-    - "sphinx-build -WT -b dummy -d docs docs docs/_build/html"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 python:
     - "3.6"
+    - "3.7"
 install: 
     - pip install tox
     - pip install -r docs/requirements.txt
-script: 
+script:
+    - flake8 src
     - tox
     - "sphinx-build -WT -b dummy -d docs docs docs/_build/html"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: true
 git:
   depth: 3
 language: python
@@ -7,6 +7,7 @@ python:
     - "3.7-dev"
 install:
     - pip install tox flake8
+    - sudo apt-get install libhdf5-dev
 script:
     - flake8 src
     - tox

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -164,7 +164,8 @@ def model_context_from_settings(execution_context, settings):
 
     add_mortality_data(model_context, execution_context, settings.model.drill_sex)
     add_omega_constraint(model_context, execution_context, settings.model.drill_sex)
-    model_context.average_integrand_cases = make_average_integrand_cases_from_gbd(execution_context, [settings.model.drill_sex])
+    model_context.average_integrand_cases = make_average_integrand_cases_from_gbd(
+        execution_context, [settings.model.drill_sex])
 
     fixed_effects_from_epiviz(model_context, execution_context, settings)
     random_effects_from_epiviz(model_context, settings)

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,8 @@ envlist = py36
 xfail_strict = true
 testpaths = tests
 [testenv]
-extras=testing,documentation
-commands=py.test
+extras = testing
+commands = py.test
 [testenv:docs]
-description = Use sphinx-build to test the HTML docs
-basepython = python3.6
-deps = sphinx
+extras = documentation
 commands = sphinx-build -WT -b dummy -d docs docs docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,docs
+envlist = py37,docs
 [pytest]
 xfail_strict = true
 testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,10 @@ envlist = py36
 xfail_strict = true
 testpaths = tests
 [testenv]
-extras=testing
+extras=testing,documentation
 commands=py.test
+[testenv:docs]
+description = Use sphinx-build to test the HTML docs
+basepython = python3.6
+deps = sphinx
+commands = sphinx-build -WT -b dummy -d docs docs docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36,docs
 [pytest]
 xfail_strict = true
 testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,docs
+envlist = py36,docs
 [pytest]
 xfail_strict = true
 testpaths = tests


### PR DESCRIPTION
- Gets rid of "pip install -r docs/requirements.txt" so tests will be faster. The rqmts.txt file still necessary for readthedocs.org, though.
- Adds a test of flake8.
- moves the docs-building into the tox code, out of Travis.
- takes away sudo privileges, which means it runs in a Docker, which means it gets scheduled faster by Travis, according to their documentation.
- gets rid of git depth, so less downloading from git.
