### PR TITLE
Write csv files so modelers can compare AT and ODE save results data

### DIFF
--- a/docs/user/dmsr2csv.rst
+++ b/docs/user/dmsr2csv.rst
@@ -2,22 +2,28 @@ DMSR2CSV Tool
 =============
 
 This is a script that retrieves model results for Dismod AT and ODE models
-and writes it as a csv file for each model type.  The data is retrieved from
-the ``epi.model_estimate_fit`` table.  The database used for AT is ``dismod-at-dev``
-and for ODE is ``epi``.
+and writes it as a csv file for each model type.  The data is retrieved from either
+the ``epi.model_estimate_fit`` or ``epi.model_estimate_final`` table from one of these
+databases, ``dismod-at-dev``, ``dismod-at-prod``, ``epi``, or ``epi-test``.
 
 The input required is a ``model_version_id`` for each model type.  Optionally, an
 output directory can be specified for the csv files, otherwise, they will be
 written to the current directory.  If an invalid ``model_version_id`` is provided
 or if no ``model_version_id`` is provided, an empty dataframe will be retrieved and 
-a csv file with no rows of data will be written.  
+a csv file with no rows of data will be written.  The database to use, and the table 
+within that database, can be supplied for each model_version_id.  If the database and
+table are not both supplied, the possible combinations from the database and table 
+lists above are checked for a given ``model_version_id``.  If data is found in more
+than one of the database+table combinations for a ``model_version_id``, the locations 
+found are reported, and no data is written for that ``model_version_id``.  If the 
+database and table are provided in a new run, the data will be retrieved and written.
 
 The output is a csv file for an AT model and a csv file for an ODE model.
 These files have the names: ``at_<mvid>.csv`` and ``ode_<mvid>.csv``, where <mvid> 
 stands for the model_version_id provided for each model type.  
 
 The columns in the output files are the same as those in the ``epi.model_estimate_fit`` 
-table:
+and ``epi.model_estimate_final`` tables:
 
  * model_version_id
  * year_id
@@ -35,14 +41,24 @@ To run the script on the cluster:
 
     cluster> source /ihme/code/dismod_at/env/current/bin/activate
 
-2. Run the script and supply values for <x>, <y>, and <d>:: 
+2. Run the script and supply values for <x>, <y>, <d>, <xdb>, <xt>, <ydb>, <yt>:: 
 
-    cluster> dmsr2csv --at-mvid=<x> --ode-mvid=<y> --output-dir=<d>     
+    cluster> dmsr2csv --at-mvid=<x> --ode-mvid=<y> --output-dir=<d> --at-db=<xdb> --at-table=<xt> --ode-db=<ydb> --ode-table=<yt>     
+
+
+The possible values for <xdb> or <ydb> are: "at-dev", "at-prod", "epi-dev", or "epi-prod"
+
+and 
+
+the possible values for <xt> or <yt> are: "fit" or "final"
+
+Both the database and table should be specified, if using these arguments (not just one of the two).  
+
 
 
 An example call to ``dmsr2csv`` is::
 
-    dmsr2csv --at-mvid=265844 --ode-mvid=102680 --output-dir=/ihme/code/someusername/somedir
+    dmsr2csv --at-mvid=265844 --ode-mvid=102680 --output-dir=/ihme/code/someusername/somedir --at-db="at-dev" --at-table="fit" --ode-db="epi-prod" --ode-table="fit"
 
 Two csv files will be written to ``/ihme/code/someusername/somedir``::
 

--- a/src/cascade/executor/model_results_main.py
+++ b/src/cascade/executor/model_results_main.py
@@ -15,28 +15,42 @@ from cascade.core.db import connection
 CODELOG = logging.getLogger(__name__)
 
 
-dbs = ["epi-dev":"epi-test",
-           "epi-prod":"epi",
-           "at-dev":"dismod-at-dev",
-           "at-prod":"dismod-at-prod"]
+dbs = {"epi-dev": "epi-test",
+       "epi-prod": "epi",
+       "at-dev": "dismod-at-dev",
+       "at-prod": "dismod-at-prod"}
 
-tables = {"fit":"epi.model_estimate_fit", "final":"epi.model_estimate_final"}
+dbs_easy_names = {"epi-test": "epi-dev",
+                  "epi": "epi-prod",
+                  "dismod-at-dev": "at-dev",
+                  "dismod-at-prod": "at-prod"}
+
+tables = {"fit": "epi.model_estimate_fit", "final": "epi.model_estimate_final"}
+
+tables_easy_names = {"epi.model_estimate_fit": "fit", "epi.model_estimate_final": "final"}
 
 
-def _check_database(db, table):
-    """
+def _retrieve_from_database(model_version_id, db, table):
+    """Connect to the database and retrieve the results.
+
+    Args:
+        db (str): nickname of the IHME database, as used in a .odbc.ini file
+        table (str): name of the table in the database
+
+    Returns:
+        pandas.DataFrame() of the retrieved results
     """
 
     query = f"""
     SELECT * FROM {table}
     WHERE
-	model_version_id = %(model_version_id)s
+        model_version_id = %(model_version_id)s
     """
 
     with connection(database=db) as c:
         model_results_data = pd.read_sql(query, c, params={"model_version_id": model_version_id})
-        CODELOG.debug(f"""Downloaded {len(model_results_data)} lines of dismod {model_type}
-                      data for model_version_id {model_version_id} from '{database}'""")
+        CODELOG.debug(f"""Downloaded {len(model_results_data)} lines of
+                      data for model_version_id {model_version_id} from '{db}'""")
 
     return model_results_data
 
@@ -59,26 +73,35 @@ def _get_model_results(model_version_id, db, table):
         pandas.DataFrame: containing all columns in the "save results" upload table
     """
 
-    if(db and table):
-        model_results_data = _check_database(db, table)
+    if db and table:
+        if db in dbs.keys() and table in tables.keys():
+            model_results_data = _retrieve_from_database(model_version_id, dbs[db], tables[table])
+            return model_results_data
+        else:
+            sys.exit(f"""Unknown db and table combination.  Acceptable databases are
+                     {dbs.keys()} and acceptable tables are {tables.keys()}""")
     else:
         # check all, if find more than one report it, else return one
-        model_results = []
+        model_results = None
+        model_results_empty = None
         model_results_db_and_table = []
-        for db, table in it.product(dbs.keys(), tables.keys()):
-            model_results_data = _check_database(db, table)
-            if not model_results_data.empty:
-                model_results.append(model_results_data)     
-                model_results_db_and_table.append((db,table))
-        if len(model_results) > 1:
+        for db, table in it.product(dbs.values(), tables.values()):
+            model_results_retrieved = _retrieve_from_database(model_version_id, db, table)
+            if not model_results_retrieved.empty:
+                model_results_db_and_table.append((dbs_easy_names[db], tables_easy_names[table]))
+                model_results = model_results_retrieved
+            else:
+                model_results_empty = model_results_retrieved
+        if len(model_results_db_and_table) > 1:
             # exit and report
-            sys.exit(f"""Found {model_version_id} in multiple locations 
+            sys.exit(f"""Found {model_version_id} in multiple (database, table) locations
                      {model_results_db_and_table}
                      Please identify the one you want and try again.""")
+        elif len(model_results_db_and_table) == 1:
+            return model_results[0]
         else:
-            model_results_data = model_results[0]
-
-    return model_results_data
+            # returns an empty database, if none of the db/table combinations contains the model_version_id
+            return model_results_empty
 
 
 def _write_model_results(model_results, model_version_id, model_type, output_dir):
@@ -93,6 +116,10 @@ def entry():
 
     If the user does not provide an at_mvid, an empty dataframe is written as at_None.csv;
     similarly if no ode_mvid is provided, an empty ode_None.csv is written.
+
+    If no values are provided for db and table, a selected set of db's and tables are checked.  If
+    the data is found in more than one place, the multiple locations are reported, no data is written for
+    that mvid, and the program exits.
     """
     parser = ArgumentParser("Writes two csv files, one for Dismod AT results and one for Dismod ODE results.")
     parser.add_argument("--at-mvid", help="model_version_id for AT results")
@@ -115,8 +142,8 @@ def entry():
         sys.exit(f"""Error: Directory provided: {args.output_dir} does not exist.
                             Please create first, or check the spelling.""")
 
-    at_results = _get_model_results(args.at_mvid, "AT")
-    ode_results = _get_model_results(args.ode_mvid, "ODE")
+    at_results = _get_model_results(args.at_mvid, args.at_db, args.at_table)
+    ode_results = _get_model_results(args.ode_mvid, args.ode_db, args.ode_table)
 
     _write_model_results(at_results, args.at_mvid, "AT", args.output_dir)
     _write_model_results(ode_results, args.ode_mvid, "ODE", args.output_dir)

--- a/tests/executor/test_model_results_main.py
+++ b/tests/executor/test_model_results_main.py
@@ -11,14 +11,16 @@ def test_get_model_results_inputs_ok(ihme):
                        'age_group_id', 'measure_id', 'mean', 'upper', 'lower']
 
     ode_model_version_id = 102680
-    ode_model_type = "ODE"
-    ode_results = _get_model_results(ode_model_version_id, ode_model_type)
+    db = "epi-prod"
+    table = "fit"
+    ode_results = _get_model_results(ode_model_version_id, db, table)
 
     assert set(ode_results.columns) == set(results_columns)
 
     at_model_version_id = 265844
-    at_model_type = "AT"
-    at_results = _get_model_results(at_model_version_id, at_model_type)
+    db = "at-dev"
+    table = "fit"
+    at_results = _get_model_results(at_model_version_id, db, table)
 
     assert set(at_results.columns) == set(results_columns)
 
@@ -29,19 +31,31 @@ def test_get_model_results_inputs_ok(ihme):
                                    check_exact=False, check_names=False)
 
 
-def test_get_model_results_bad_model_type(ihme):
-    """Expect an exception if model_type is not AT or ODE"""
-    with pytest.raises(ValueError):
+def test_get_model_results_bad_database_name(ihme):
+    """Expect an exception if db not 'epi-dev', 'epi-prod', 'at-dev', or 'at-prod'"""
+    with pytest.raises(SystemExit):
         model_version_id = 265844
-        model_type = "NOT_AT_OR_ODE"
-        _get_model_results(model_version_id, model_type)
+        db = "not-at-dev"
+        table = "fit"
+        _get_model_results(model_version_id, db, table)
+
+
+def test_get_model_results_bad_table_name(ihme):
+    """Expect an exception if table not 'fit', 'final'"""
+    with pytest.raises(SystemExit):
+        model_version_id = 265844
+        db = "at-dev"
+        table = "not-fit"
+        _get_model_results(model_version_id, db, table)
 
 
 def test_get_model_results_bad_model_version_id(ihme):
     """Expect an empty dataframe if model_version_id is not in the database"""
 
     at_model_version_id = 1
-    at_model_type = "AT"
-    at_results = _get_model_results(at_model_version_id, at_model_type)
+    db = "at-dev"
+    table = "fit"
+
+    at_results = _get_model_results(at_model_version_id, db, table)
 
     assert at_results.empty


### PR DESCRIPTION
This is the second PR for this task.  Database and table are now offered as arguments to the program, so that we can pin-point the source of the data.  In the previous version, one db and table was checked for AT and a separate db and table for ODE.  When a modeler ran the program, no data was found, because though the data exists, it did not exist in the one place checked for each model type.  