### PR TITLE
Acceptance tests around mortality data

### DIFF
--- a/acceptance/test_mortality.py
+++ b/acceptance/test_mortality.py
@@ -1,0 +1,108 @@
+from subprocess import run
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+
+from db_queries import get_envelope, get_outputs
+
+from cascade.executor.epiviz_runner import add_settings_to_execution_context
+from cascade.input_data.db.configuration import load_settings
+from cascade.dismod.db.metadata import IntegrandEnum
+from cascade.input_data.db.demographics import age_groups_to_ranges
+from cascade.dismod.db.wrapper import DismodFile, _get_engine
+from cascade.testing_utilities import make_execution_context
+from cascade.core.db import cursor
+
+
+def _prepare_output_data_for_test(execution_context, clear_bundle=False):
+    mvid = execution_context.parameters.model_version_id
+
+    # Clear out all the tier 3 tables so we are looking at fresh data
+    table_names = ["t3_model_version_asdr", "t3_model_version_csmr", "t3_model_version_study_covariate"]
+    if clear_bundle:
+        # rebuilding the t3 bundle can be expensive so only clear it if we need to
+        table_names.append("t3_model_version_dismod")
+    for table_name in [
+        "t3_model_version_asdr",
+        "t3_model_version_csmr",
+        "t3_model_version_dismod",
+        "t3_model_version_study_covariate",
+    ]:
+        clear_table = f"delete from {table_name} where model_version_id = {mvid}"
+        with cursor(execution_context) as c:
+            c.execute(clear_table)
+
+    with TemporaryDirectory() as d:
+        db_path = Path(d) / "test.db"
+        run(f"dmcascade {db_path} --mvid {mvid} --db-only".split(), check=True)
+        dm = DismodFile(_get_engine(db_path))
+        return dm.data
+
+
+def test_asdr_data():
+    mvid = 266156
+    execution_context = make_execution_context()
+    settings = load_settings(execution_context, mvid=mvid)
+    add_settings_to_execution_context(execution_context, settings)
+
+    data = _prepare_output_data_for_test(execution_context)
+    data = data.loc[data.integrand_id == IntegrandEnum.mtall.value]
+
+    expected = get_envelope(
+        location_id=execution_context.parameters.location_id,
+        year_id="all",
+        gbd_round_id=execution_context.parameters.gbd_round_id,
+        age_group_id="all",
+        sex_id="all",
+        with_hiv=True,
+        rates=True,
+    )
+
+    expected = age_groups_to_ranges(execution_context, expected)
+
+    # The actual years used depend on the input bundle. I'm going to assume that part works
+    years = data.time_lower.unique()  # noqa: F841
+    expected = expected.query("year_id in @years")
+
+    expected = expected.query("sex_id == @settings.model.drill_sex")
+
+    expected_mean = expected.sort_values(["age_lower", "year_id"]).reset_index(drop=True)["mean"]
+
+    actual_mean = data.sort_values(["age_lower", "time_lower"]).reset_index(drop=True)["meas_value"]
+
+    assert np.allclose(expected_mean, actual_mean)
+
+
+def test_csmr_data():
+    mvid = 266156
+    execution_context = make_execution_context()
+    settings = load_settings(execution_context, mvid=mvid)
+    add_settings_to_execution_context(execution_context, settings)
+
+    data = _prepare_output_data_for_test(execution_context)
+    data = data.loc[data.integrand_id == IntegrandEnum.mtspecific.value]
+
+    expected = get_outputs(
+        topic="cause",
+        cause_id=execution_context.parameters.add_csmr_cause,
+        location_id=execution_context.parameters.location_id,
+        metric_id=3,
+        year_id="all",
+        age_group_id="most_detailed",
+        measure_id=1,
+        sex_id="all",
+        gbd_round_id=execution_context.parameters.gbd_round_id,
+        version="latest",
+    )
+    expected = expected[expected["val"].notnull()]
+
+    expected = age_groups_to_ranges(execution_context, expected)
+
+    expected = expected.query("sex_id == @settings.model.drill_sex")
+
+    expected_mean = expected.sort_values(["age_lower", "year_id"]).reset_index(drop=True)["val"]
+
+    actual_mean = data.sort_values(["age_lower", "time_lower"]).reset_index(drop=True)["meas_value"]
+
+    assert np.allclose(expected_mean, actual_mean)

--- a/src/cascade/input_data/db/__init__.py
+++ b/src/cascade/input_data/db/__init__.py
@@ -3,8 +3,6 @@ CODELOG, MATHLOG = getLoggers(__name__)
 
 AGE_GROUP_SET_ID = 12
 
-GBD_ROUND_ID = 5
-
 METRIC_IDS = {"per_capita_rate": 3}
 
 MEASURE_IDS = {"deaths": 1}

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -3,10 +3,11 @@
 import pandas as pd
 
 from cascade.core.db import cursor, db_queries
-from cascade.input_data.db import AGE_GROUP_SET_ID, GBD_ROUND_ID
+from cascade.input_data.db import AGE_GROUP_SET_ID
 
 
 from cascade.core.log import getLoggers
+
 CODELOG, MATHLOG = getLoggers(__name__)
 
 
@@ -33,14 +34,14 @@ def _get_asdr_data(execution_context):
 
     parent_loc = execution_context.parameters.location_id
 
-    demo_dict = db_queries.get_demographics(gbd_team="epi", gbd_round_id=GBD_ROUND_ID)
+    demo_dict = db_queries.get_demographics(gbd_team="epi", gbd_round_id=execution_context.parameters.gbd_round_id)
     age_group_ids = demo_dict["age_group_id"]
     sex_ids = demo_dict["sex_id"]
 
     asdr = db_queries.get_envelope(
         location_id=parent_loc,
         year_id=-1,
-        gbd_round_id=GBD_ROUND_ID,
+        gbd_round_id=execution_context.parameters.gbd_round_id,
         age_group_id=age_group_ids,
         sex_id=sex_ids,
         with_hiv=True,
@@ -49,9 +50,9 @@ def _get_asdr_data(execution_context):
 
     asdr = asdr[asdr["mean"].notnull()]
 
-    age_group_data = db_queries.get_age_metadata(age_group_set_id=AGE_GROUP_SET_ID, gbd_round_id=GBD_ROUND_ID)[
-        ["age_group_id", "age_group_years_start", "age_group_years_end"]
-    ]
+    age_group_data = db_queries.get_age_metadata(
+        age_group_set_id=AGE_GROUP_SET_ID, gbd_round_id=execution_context.parameters.gbd_round_id
+    )[["age_group_id", "age_group_years_start", "age_group_years_end"]]
 
     age_group_data.columns = ["age_group_id", "age_lower", "age_upper"]
 

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -3,7 +3,7 @@
 import pandas as pd
 
 from cascade.core.db import cursor, db_queries
-from cascade.input_data.db import GBD_ROUND_ID, METRIC_IDS, MEASURE_IDS
+from cascade.input_data.db import METRIC_IDS, MEASURE_IDS
 
 
 from cascade.core.log import getLoggers
@@ -45,7 +45,7 @@ def _get_csmr_data(execution_context):
         age_group_id="most_detailed",
         measure_id=MEASURE_IDS["deaths"],
         sex_id="all",
-        gbd_round_id=GBD_ROUND_ID,
+        gbd_round_id=execution_context.parameters.gbd_round_id,
         version="latest",
     )[keep_cols]
 


### PR DESCRIPTION
One outstanding question I have here is how to think about the relationship between these tests and the database. They depend on building a fresh tier3 and so must delete the tier3 data for the mvid they test and reupload the data. I've chosen a mvid that no one cares about but it may disappear at some point and the fact the test is dramatically modifying a shared database at all makes me nervous. I'm not sure how to do better at this point.