### PR TITLE
Give some control over the order in which form sections are validated

### DIFF
--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -234,16 +234,18 @@ class Configuration(Form):
 
     """
 
-    model = Model(display="Model")
+    model = Model(display="Model", validation_priority=5)
     policies = Policies(display="Policies")
     gbd_round_id = IntField(display="GBD Round ID")
     random_effect = FormList(Smoothing, nullable=True, display="Random effects")
     rate = FormList(Smoothing, display="Rates")
     study_covariate = FormList(StudyCovariate, display="Study covariates")
     country_covariate = FormList(CountryCovariate, display="Country covariates")
-    eta = Eta()
-
+    eta = Eta(validation_priority=5)
+    students_dof = StudentsDOF(validation_priority=5)
+    log_students_dof = StudentsDOF(validation_priority=5)
     csmr_cod_output_version_id = IntField()
+
     csmr_mortality_output_version_id = Dummy()
     location_set_version_id = Dummy()
     min_cv = FormList(Dummy)
@@ -254,8 +256,6 @@ class Configuration(Form):
     print_level = Dummy()
     accept_after_max_steps = Dummy()
     tolerance = Dummy()
-    students_dof = StudentsDOF()
-    log_students_dof = StudentsDOF()
     data_eta_by_integrand = Dummy()
     data_density_by_integrand = Dummy()
     config_version = Dummy()

--- a/tests/core/form/test_abstract_form.py
+++ b/tests/core/form/test_abstract_form.py
@@ -207,3 +207,26 @@ def test_subform_with_defaults():
     errors = f.validate_and_normalize()
     assert not errors
     assert f.inner.a == 42
+
+
+def test_alidation_priority():
+    class InnerOne(Form):
+        a = SimpleTypeField(int)
+
+        def _full_form_validation(self, root):
+            assert isinstance(root.two.b, int)
+            return []
+
+    class InnerTwo(Form):
+        b = SimpleTypeField(int, validation_priority=5)
+
+        def _full_form_validation(self, root):
+            assert isinstance(root.one.a, str)
+            return []
+
+    class MyForm(Form):
+        one = InnerOne()
+        two = InnerTwo()
+
+    f = MyForm({"one": {"a": "10"}, "two": {"b": "15"}})
+    f.validate_and_normalize()


### PR DESCRIPTION
I'm not 100% happy with this solution but it's the simplest fix I could think of. It allows users to specify a priority on form section validation. The alternative would be a topo sort. The problem it solves is situations where a form needs to access elements from parents or siblings during validation. Previously there was no way to know if those had been validated or normalized yet. Now you can force an ordering.