### PR TITLE
Bugfix/estimate emr fails

### DIFF
--- a/tests/input_data/configuration/test_build_mortality.py
+++ b/tests/input_data/configuration/test_build_mortality.py
@@ -9,7 +9,9 @@ import pytest
 @pytest.mark.parametrize("sexes", [1, 2])
 def test_add_mortality_data(ihme, sexes):
     ec = make_execution_context(model_version_id=265976, gbd_round_id=5)
+    ec.policies = dict(use_weighted_age_group_midpoints=0)
     mc = ModelContext()
+    mc.policies = dict(estimate_emr_from_prevalence=0)
     mc.input_data.observations = pd.DataFrame(
         columns=["time_upper", "time_lower", "age_upper", "age_lower", "measure", "hold_out"]
     )
@@ -24,7 +26,9 @@ def test_add_mortality_data(ihme, sexes):
 @pytest.mark.parametrize("sexes", [1, 2])
 def test_add_omega_constraint(ihme, sexes):
     ec = make_execution_context(model_version_id=265976, gbd_round_id=5)
+    ec.policies = dict(use_weighted_age_group_midpoints=0)
     mc = ModelContext()
+    mc.policies = dict(estimate_emr_from_prevalence=0)
     mc.input_data.observations = pd.DataFrame(
         {"time_lower": [1970.0],
          "time_upper": [1971.0],


### PR DESCRIPTION
A bug got into the tests that use --ihme from the new policies. This makes the test run with the policies. It also found a hidden bug where emr would fail if there were no prevalence measurements, so it fixes that.