### PR TITLE
infer rate cases and validate fixed effects lower bounds

### DIFF
--- a/src/cascade/core/form/fields.py
+++ b/src/cascade/core/form/fields.py
@@ -42,6 +42,7 @@ class FormList(Form):
         for i, inner_source in enumerate(source):
             form = self._inner_form_constructor()
             form._name = str(i)
+            form._container = self
             form.process_source(inner_source)
             forms.append(form)
         self._forms = forms

--- a/src/cascade/dismod/serialize.py
+++ b/src/cascade/dismod/serialize.py
@@ -594,7 +594,7 @@ def make_covariate_table(context):
 
 def make_option_table(context):
     options = {
-        "rate_case": context.parameters.rate_case,
+        "rate_case": _infer_rate_case(context),
         "parent_node_id": "0",
         "print_level_fixed": "5",
         "ode_step_size": "1",
@@ -602,3 +602,19 @@ def make_option_table(context):
     }
 
     return pd.DataFrame([{"option_name": k, "option_value": v} for k, v in sorted(options.items())])
+
+
+def _infer_rate_case(context):
+    iota = context.rates.iota
+    rho = context.rates.rho
+
+    if iota.zero and rho.zero:
+        return "iota_zero_rho_zero"
+    elif iota.positive and rho.zero:
+        return "iota_pos_rho_zero"
+    elif iota.zero and rho.positive:
+        return "iota_zero_rho_pos"
+    elif iota.positive and rho.positive:
+        return "iota_pos_rho_pos"
+    else:
+        raise ValueError("Impossible rate_case. Iota or Rho has negative limits?")

--- a/src/cascade/dismod/serialize.py
+++ b/src/cascade/dismod/serialize.py
@@ -617,4 +617,13 @@ def _infer_rate_case(context):
     elif iota.positive and rho.positive:
         return "iota_pos_rho_pos"
     else:
-        raise ValueError("Impossible rate_case. Iota or Rho has negative limits?")
+        problems = []
+        if not iota.zero and not iota.positive:
+            problems.append("iota")
+        if not rho.zero and not rho.positive:
+            problems.append("rho")
+        raise ValueError(
+            f"Impossible rate_case. In order to select a rate case for dismodat "
+            f"iota and rho must be completely constrained to zero or constrained "
+            f"to always be > than 0. Problematic rates: {problems}"
+        )

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -129,6 +129,13 @@ class Smoothing(Form):
         if len(time_grid) > 1 and self.default.is_field_unset("dtime"):
             errors.append("You must supply a default time diff prior if the smoothing has extent over time")
 
+        if self._name == "rates":
+            # This validation only makes sense for Fixed Effects not Random Effects
+            for prior in [self.default.value] + [p for p in self.detail or [] if p.prior_type == "value"]:
+                if prior.min < 0:
+                    errors.append("Rates must be constrained to be >= 0 at all points. Add or correct the lower bound")
+                    break
+
         return errors
 
 
@@ -183,12 +190,7 @@ class Model(Form):
     birth_prev = OptionField([0, 1], constructor=int, nullable=True, default=0, display="Prevalence at birth")
     default_age_grid = StringListField(constructor=float, display="(Cascade) Age grid")
     default_time_grid = StringListField(constructor=float, display="(Cascade) Time grid")
-    rate_case = OptionField(
-        ["iota_zero_rho_pos", "iota_pos_rho_zero", "iota_zero_rho_zero", "iota_pos_rho_pos"],
-        nullable=True,
-        default="iota_pos_rho_zero",
-        display="(Advanced) Rate case",
-    )
+    rate_case = Dummy()
 
     def _full_form_validation(self, root):
         errors = []

--- a/src/cascade/model/rates.py
+++ b/src/cascade/model/rates.py
@@ -88,5 +88,25 @@ class Rate:
             smoothings.append(self.parent_smooth)
         return smoothings
 
+    @property
+    def positive(self):
+        if self.parent_smooth is None:
+            return False
+        else:
+            for prior in self.parent_smooth.value_priors.priors:
+                if prior.lower > 0:
+                    return True
+            return False
+
+    @property
+    def zero(self):
+        if self.parent_smooth is None:
+            return True
+        else:
+            for prior in self.parent_smooth.value_priors.priors:
+                if prior.lower != 0 or prior.upper != 0:
+                    return False
+            return True
+
     def __repr__(self):
         return f"<Rate '{self.name}'>"

--- a/src/cascade/model/rates.py
+++ b/src/cascade/model/rates.py
@@ -94,9 +94,9 @@ class Rate:
             return False
         else:
             for prior in self.parent_smooth.value_priors.priors:
-                if prior.lower > 0:
-                    return True
-            return False
+                if prior.lower <= 0:
+                    return False
+            return True
 
     @property
     def zero(self):

--- a/tests/dismod/test_serialize.py
+++ b/tests/dismod/test_serialize.py
@@ -24,6 +24,7 @@ from cascade.dismod.serialize import (
     make_data_table,
     make_rate_table,
     make_mulcov_table,
+    _infer_rate_case,
 )
 from cascade.dismod.db.wrapper import DismodFile, _get_engine
 from cascade.dismod.db.metadata import DensityEnum
@@ -97,7 +98,7 @@ def base_context(observations, constraints):
     d_age = PriorGrid(grid)
     d_age[:, :].prior = Gaussian(0, 0.1, name="TestPrior")
     value = PriorGrid(grid)
-    value[:, :].prior = Gaussian(0, 0.1)
+    value[:, :].prior = Gaussian(0.1, 0.1, lower=0.01)
 
     smooth = Smooth(name="iota_smooth")
     smooth.d_time_priors = d_time
@@ -160,7 +161,7 @@ def test_collect_priors(base_context):
         Gaussian(0, 0.1, name="TestPrior"),
         Uniform(0, 1, 0.5),
         Gaussian(1, 0.1),
-        Gaussian(0, 0.1),
+        Gaussian(0.1, 0.1, lower=0.01),
         Gaussian(0, 0.1, eta=1),
     }
 
@@ -334,3 +335,8 @@ def test_make_covariate_table(base_context):
     make_mulcov_table(
         base_context, smooth_id_func, rate_to_id, integrand_to_id, cov_id_func
     )
+
+
+def test_infer_rate_case(base_context):
+    case = _infer_rate_case(base_context)
+    assert case == "iota_pos_rho_zero"

--- a/tests/input_data/configuration/test_builder.py
+++ b/tests/input_data/configuration/test_builder.py
@@ -65,7 +65,7 @@ def base_config():
                     "default": {
                         "dage": {"density": "gaussian", "mean": 0, "std": 0.1},
                         "dtime": {"density": "gaussian", "mean": 0, "std": 0.2},
-                        "value": {"density": "gaussian", "mean": 0, "std": 0.3},
+                        "value": {"density": "gaussian", "min": 0.00001, "mean": 0.00001, "std": 0.3},
                     },
                     "detail": [
                         {
@@ -75,7 +75,8 @@ def base_config():
                             "time_lower": 1995,
                             "time_upper": 2005,
                             "density": "students",
-                            "mean": 0,
+                            "min": 0.00001,
+                            "mean": 0.00002,
                             "std": 0.25,
                             "nu": 1,
                         }
@@ -102,8 +103,8 @@ def test_make_smooth(base_config):
     assert smooth.d_age_priors.priors == {priors.Gaussian(mean=0, standard_deviation=0.1, name="dA")}
     assert smooth.d_time_priors.priors == {priors.Gaussian(mean=0, standard_deviation=0.2, name="dT")}
     assert smooth.value_priors.priors == {
-        priors.Gaussian(mean=0, standard_deviation=0.3, name="value"),
-        priors.StudentsT(mean=0, standard_deviation=0.25, nu=1, name="value_20.0_40.0_1995.0_2005.0"),
+        priors.Gaussian(mean=1e-05, standard_deviation=0.3, name="value", lower=1e-05),
+        priors.StudentsT(mean=2e-05, standard_deviation=0.25, nu=1, lower=1e-05, name="value_20.0_40.0_1995.0_2005.0"),
     }
     assert set(smooth.grid.ages) == {0.0, 20.0, 40.0, 60.0, 80.0}
     assert set(smooth.grid.times) == {1990.0, 1995.0, 2000.0, 2005.0, 2010.0}
@@ -111,13 +112,14 @@ def test_make_smooth(base_config):
     for age in smooth.grid.ages:
         for time in smooth.grid.times:
             if age in {20.0, 40.0} and time in {1995.0, 2000.0, 2005.0}:
-                expected = priors.StudentsT(mean=0,
+                expected = priors.StudentsT(mean=2e-05,
                                             standard_deviation=0.25,
+                                            lower=1e-05,
                                             nu=1,
                                             name="value_20.0_40.0_1995.0_2005.0")
                 assert smooth.value_priors[20, 2000].prior == expected
             else:
-                expected = priors.Gaussian(mean=0, standard_deviation=0.3, name="value")
+                expected = priors.Gaussian(mean=1e-05, standard_deviation=0.3, lower=1e-05, name="value")
                 assert smooth.value_priors[0, 1990].prior == expected
 
 

--- a/tests/model/test_rates.py
+++ b/tests/model/test_rates.py
@@ -17,7 +17,7 @@ def test_positive():
     positive_and_negative_pg = PriorGrid(grid)
     positive_and_negative_pg[:, :].prior = priors.Gaussian(0.1, 0.1, lower=0.01)
     positive_and_negative_pg[0, 1995].prior = priors.Uniform(0, 0)
-    assert Rate("iota", parent_smooth=Smooth(positive_and_negative_pg)).positive
+    assert not Rate("iota", parent_smooth=Smooth(positive_and_negative_pg)).positive
 
     assert not Rate("iota", parent_smooth=None).positive
 

--- a/tests/model/test_rates.py
+++ b/tests/model/test_rates.py
@@ -1,0 +1,41 @@
+from cascade.model.rates import Rate, Smooth
+from cascade.model.grids import PriorGrid, AgeTimeGrid
+from cascade.model import priors
+
+
+def test_positive():
+    grid = AgeTimeGrid.uniform(age_lower=0, age_upper=120, age_step=5, time_lower=1990, time_upper=2018, time_step=1)
+
+    positive_pg = PriorGrid(grid)
+    positive_pg[:, :].prior = priors.Gaussian(0.1, 0.1, lower=0.01)
+    assert Rate("iota", parent_smooth=Smooth(positive_pg)).positive
+
+    zero_pg = PriorGrid(grid)
+    zero_pg[:, :].prior = priors.Uniform(0, 0)
+    assert not Rate("iota", parent_smooth=Smooth(zero_pg)).positive
+
+    positive_and_negative_pg = PriorGrid(grid)
+    positive_and_negative_pg[:, :].prior = priors.Gaussian(0.1, 0.1, lower=0.01)
+    positive_and_negative_pg[0, 1995].prior = priors.Uniform(0, 0)
+    assert Rate("iota", parent_smooth=Smooth(positive_and_negative_pg)).positive
+
+    assert not Rate("iota", parent_smooth=None).positive
+
+
+def test_zero():
+    grid = AgeTimeGrid.uniform(age_lower=0, age_upper=120, age_step=5, time_lower=1990, time_upper=2018, time_step=1)
+
+    assert Rate("iota", parent_smooth=None).zero
+
+    zero_pg = PriorGrid(grid)
+    zero_pg[:, :].prior = priors.Uniform(0, 0)
+    assert Rate("iota", parent_smooth=Smooth(zero_pg)).zero
+
+    positive_pg = PriorGrid(grid)
+    positive_pg[:, :].prior = priors.Gaussian(0.1, 0.1, lower=0.01)
+    assert not Rate("iota", parent_smooth=Smooth(positive_pg)).zero
+
+    positive_and_negative_pg = PriorGrid(grid)
+    positive_and_negative_pg[:, :].prior = priors.Gaussian(0.1, 0.1, lower=0.01)
+    positive_and_negative_pg[0, 1995].prior = priors.Uniform(0, 0)
+    assert not Rate("iota", parent_smooth=Smooth(positive_and_negative_pg)).zero


### PR DESCRIPTION
The "rate case" configuration in the "Advanced" tab is confusing and redundant. This change adds code to infer the correct rate case to use based on the priors the user supplied. It also adds stricter validation on the bounds for fixed effect priors.