### PR TITLE
Enhancement/more html structure in math log

### DIFF
--- a/src/cascade/executor/argument_parser.py
+++ b/src/cascade/executor/argument_parser.py
@@ -13,6 +13,8 @@ import tempfile
 
 import pkg_resources
 
+from cascade.executor.math_log import MathLogFormatter
+
 from cascade.core.log import getLoggers
 CODELOG, MATHLOG = getLoggers(__name__)
 
@@ -217,9 +219,7 @@ class BaseArgumentParser(ArgumentParser):
                             f"directory {math_log_dir} exists: {mhe}")
             return
         # The br is an HTML tag to add a line break.
-        fmt = "%(levelname)s %(asctime)s %(funcName)s: %(message)s<br />"
-        datefmt = "%y-%m-%d %H:%M:%S"
-        math_handler.setFormatter(logging.Formatter(fmt, datefmt))
+        math_handler.setFormatter(MathLogFormatter())
         math_handler.setLevel(logging.DEBUG)
         math_logger = logging.getLogger(f"{__name__.split('.')[0]}.math")
         math_logger.addHandler(math_handler)

--- a/src/cascade/executor/dismod_runner.py
+++ b/src/cascade/executor/dismod_runner.py
@@ -172,14 +172,14 @@ def dismod_report_info(text):
     """This ensures MATHLOG messages have a function name in the log.
     Otherwise, they show <lambda> as the function name.
     """
-    MATHLOG.info(text)
+    MATHLOG.info(text, extra=dict(is_dismod_output=True))
 
 
 def dismod_report_stderr(text):
     """This ensures MATHLOG messages have a function name in the log.
     Otherwise, they show <lambda> as the function name.
     """
-    MATHLOG.warning(text)
+    MATHLOG.warning(text, extra=dict(is_dismod_output=True))
 
 
 @asyncio.coroutine

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -354,7 +354,7 @@ def main(args):
     else:
         MATHLOG.debug(f"Only creating the base db file because 'db-only' was selected")
 
-    MATHLOG.debug(f"Completed succesfully")
+    MATHLOG.debug(f"Completed successfully")
 
 
 def entry():

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -277,12 +277,14 @@ def _async_fit_fixed_effect_samples(num_processes, dismodfile, samples):
         ))
     log_level = logging.root.level
     logging.root.setLevel(logging.CRITICAL)
-    logging.getLogger("cascade.math").setLevel(logging.CRITICAL)
+    math_root = logging.getLogger("cascade.math")
+    math_log_level = math_root.level
+    math_root.setLevel(logging.CRITICAL)
     try:
         fits = yield from asyncio.gather(*jobs)
     finally:
         logging.root.setLevel(log_level)
-        logging.getLogger("cascade.math").setLevel(log_level)
+        logging.getLogger("cascade.math").setLevel(math_log_level)
     return fits
 
 
@@ -345,7 +347,14 @@ def main(args):
         fit_fixed_effect_samples(ec, cpu_count())
 
         if not args.no_upload:
+            MATHLOG.debug(f"Uploading results to epiviz")
             save_model_results(ec)
+        else:
+            MATHLOG.debug(f"Skipping results upload because 'no-upload' was selected")
+    else:
+        MATHLOG.debug(f"Only creating the base db file because 'db-only' was selected")
+
+    MATHLOG.debug(f"Completed succesfully")
 
 
 def entry():

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -277,10 +277,12 @@ def _async_fit_fixed_effect_samples(num_processes, dismodfile, samples):
         ))
     log_level = logging.root.level
     logging.root.setLevel(logging.CRITICAL)
+    logging.getLogger("cascade.math").setLevel(logging.CRITICAL)
     try:
         fits = yield from asyncio.gather(*jobs)
     finally:
         logging.root.setLevel(log_level)
+        logging.getLogger("cascade.math").setLevel(log_level)
     return fits
 
 
@@ -291,6 +293,7 @@ def fit_fixed_effect_samples(execution_context, num_processes):
     samples = execution_context.dismodfile.data_sim.simulate_index.unique()
 
     actual_processes = min(len(samples), num_processes)
+    MATHLOG.info(f"Calculating {len(samples)} fixed effect samples")
     CODELOG.info(f"Starting parallel fixed effect sample generation using {actual_processes} processes")
     loop = asyncio.get_event_loop()
     fits = loop.run_until_complete(
@@ -335,6 +338,7 @@ def main(args):
     if not args.db_only:
         run_dismod(ec.dismodfile, "init")
         run_dismod_fit(ec.dismodfile, has_random_effects(mc))
+        MATHLOG.info(f"Successfully fit parent")
 
         num_samples = mc.policies["number_of_fixed_effect_samples"]
         make_fixed_effect_samples(ec, num_samples)

--- a/src/cascade/executor/math_log.py
+++ b/src/cascade/executor/math_log.py
@@ -58,9 +58,9 @@ class MathLogFormatter(Formatter):
         self.has_emitted_css = False
 
     def format(self, record):
-        if not self.has_emited_css:
+        if not self.has_emitted_css:
             message = _CSS
-            self.has_emited_css = True
+            self.has_emitted_css = True
         else:
             message = ""
 

--- a/src/cascade/executor/math_log.py
+++ b/src/cascade/executor/math_log.py
@@ -1,0 +1,88 @@
+from logging import Formatter
+
+_CSS = """<style>
+.dismod_block {
+    background: hsl(0, 0%, 90%);
+    padding: 5px;
+    margin: 10px;
+}
+.line_prefix {
+    color: hsl(0, 0%, 50%);
+    display: inline-block;
+    width: 25em;
+    border-right: black solid 1px;
+    margin-right: 1em;
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
+.log_line {
+}
+.time_stamp {
+    font-weight: bold;
+    padding: 10px;
+}
+.level_name {
+    display: inline-block;
+    width: 6em;
+}
+.level_name.info, .level_name.debug {
+    color: hsl(0, 0%, 50%);
+}
+.level_name.warning {
+    color: hsl(30, 100%, 45%);
+}
+.level_name.error {
+    color: red;
+}
+
+.log_line.warning {
+    background: hsl(52, 100%, 79%);
+}
+
+.log_line.error {
+    background: hsl(0, 100%, 79%);
+}
+
+</style>
+"""
+
+INSTANTANIOUSNESS_THRESHOLD = 0.5
+
+
+class MathLogFormatter(Formatter):
+    def __init__(self):
+        datefmt = "%y-%m-%d %H:%M:%S"
+        super().__init__(datefmt=datefmt)
+        self.in_dismod_output = False
+        self.last_event = 0.0
+        self.has_emited_css = False
+
+    def format(self, record):
+        if not self.has_emited_css:
+            message = _CSS
+            self.has_emited_css = True
+        else:
+            message = ""
+
+        is_dismod = record.__dict__.pop("is_dismod_output", False)
+        if self.in_dismod_output and not is_dismod:
+            message += "</div>"
+            self.in_dismod_output = False
+        elif not self.in_dismod_output and is_dismod:
+            message += "<div class='dismod_block'>"
+            self.in_dismod_output = True
+
+        if not is_dismod:
+            if record.created - self.last_event > INSTANTANIOUSNESS_THRESHOLD:
+                message += f"<div class='time_stamp'>{self.formatTime(record, self.datefmt)}</div>"
+            level_class = record.levelname.lower()
+            message += f"<div class='log_line {level_class}'>"
+            message += f"<span class='line_prefix'><span class='level_name {level_class}'>{record.levelname}</span> "
+            message += f"<span class='function_name'>{record.funcName}</span></span>"
+        self.last_event = record.created
+
+        message += record.getMessage().replace("\n", "<br/>\n")
+        if not is_dismod:
+            message += "</div>"
+
+        return message

--- a/src/cascade/executor/math_log.py
+++ b/src/cascade/executor/math_log.py
@@ -46,7 +46,7 @@ _CSS = """<style>
 </style>
 """
 
-INSTANTANIOUSNESS_THRESHOLD = 0.5
+INSTANTANEOUSNESS_THRESHOLD = 0.5
 
 
 class MathLogFormatter(Formatter):
@@ -55,7 +55,7 @@ class MathLogFormatter(Formatter):
         super().__init__(datefmt=datefmt)
         self.in_dismod_output = False
         self.last_event = 0.0
-        self.has_emited_css = False
+        self.has_emitted_css = False
 
     def format(self, record):
         if not self.has_emited_css:
@@ -73,7 +73,7 @@ class MathLogFormatter(Formatter):
             self.in_dismod_output = True
 
         if not is_dismod:
-            if record.created - self.last_event > INSTANTANIOUSNESS_THRESHOLD:
+            if record.created - self.last_event > INSTANTANEOUSNESS_THRESHOLD:
                 message += f"<div class='time_stamp'>{self.formatTime(record, self.datefmt)}</div>"
             level_class = record.levelname.lower()
             message += f"<div class='log_line {level_class}'>"

--- a/src/cascade/executor/math_log.py
+++ b/src/cascade/executor/math_log.py
@@ -66,10 +66,10 @@ class MathLogFormatter(Formatter):
 
         is_dismod = record.__dict__.pop("is_dismod_output", False)
         if self.in_dismod_output and not is_dismod:
-            message += "</div>"
+            message += "</pre>"
             self.in_dismod_output = False
         elif not self.in_dismod_output and is_dismod:
-            message += "<div class='dismod_block'>"
+            message += "<pre class='dismod_block'>"
             self.in_dismod_output = True
 
         if not is_dismod:
@@ -79,9 +79,11 @@ class MathLogFormatter(Formatter):
             message += f"<div class='log_line {level_class}'>"
             message += f"<span class='line_prefix'><span class='level_name {level_class}'>{record.levelname}</span> "
             message += f"<span class='function_name'>{record.funcName}</span></span>"
+            message += record.getMessage().replace("\n", "<br/>\n")
+        else:
+            message += record.getMessage()
         self.last_event = record.created
 
-        message += record.getMessage().replace("\n", "<br/>\n")
         if not is_dismod:
             message += "</div>"
 


### PR DESCRIPTION
We have continuing problems with modelers (and me) not being able to read the mathlogs that show up in epiviz. This is an attempt to make them more legible by adding some visual (and markup) structure to them.

Just in case you can't render HTML and CSS in your head and don't want to figure out how to visualize it without EPIViz here's a screenshot of what it would look like:
![image](https://user-images.githubusercontent.com/419770/49541068-79f1dc80-f886-11e8-8173-a035cfbba1af.png)
