### PR TITLE
added two lines for umask

### DIFF
--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -420,6 +420,9 @@ def main(args):
 
 
 def entry():
+    readable_by_all = 0o0002
+    os.umask(readable_by_all)
+
     parser = DMArgumentParser("Run DismodAT from Epiviz")
     parser.add_argument("db_file_path")
     parser.add_argument("--settings-file")


### PR DESCRIPTION
We can't read logs that were written by modelers because the umask isn't world-readable. This sets the umask. Two lines.