### PR TITLE
Feature/print job

### DIFF
--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -431,7 +431,10 @@ def entry():
     parser.add_argument("--pdb", action="store_true")
     args = parser.parse_args()
 
-    CODELOG.debug(args)
+    CODELOG.debug(f"args: {args}")
+    if "JOB_ID" in os.environ:
+        MATHLOG.info(f"Job id is {os.environ['JOB_ID']} on cluster {os.environ.get('SGE_CLUSTER_NAME', '')}")
+
     try:
         main(args)
     except SettingsError as e:


### PR DESCRIPTION
Print the Job id in sge if it's known. And the cluster (dev/prod/new one). This helps do a qstat on the job and to do qacct -j later to see how it failed.