### PR TITLE
Bugfix/remove duplicate cases

### DIFF
--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -277,7 +277,6 @@ def model_context_from_settings(execution_context, settings):
     cases = make_average_integrand_cases_from_gbd(
         execution_context, [settings.model.drill_sex], include_birth_prevalence=bool(settings.model.birth_prev)
     )
-    cases = make_average_integrand_cases_from_gbd(execution_context, [settings.model.drill_sex])
     model_context.average_integrand_cases = cases
 
     fixed_effects_from_epiviz(model_context, execution_context, settings)

--- a/src/cascade/input_data/db/mortality.py
+++ b/src/cascade/input_data/db/mortality.py
@@ -49,7 +49,7 @@ def get_frozen_cause_specific_mortality_data(execution_context):
     query = """
             SELECT
                 location_id,
-                year_id
+                year_id,
                 age_group_id,
                 sex_id,
                 mean,
@@ -77,7 +77,7 @@ def get_frozen_age_standardized_death_rate_data(execution_context):
     query = """
             SELECT
                 location_id,
-                year_id
+                year_id,
                 age_group_id,
                 sex_id,
                 mean,
@@ -95,11 +95,15 @@ def get_frozen_age_standardized_death_rate_data(execution_context):
 
 
 def normalize_mortality_data(df):
-    df = df.rename(columns={
+    rename_columns = {
         "mean": "meas_value",
         "lower": "meas_lower",
         "upper": "meas_upper",
         "year_id": "time_lower",
-    })
+    }
+    if not set(rename_columns.keys()).issubset(set(df.columns)):
+        missing = ", ".join(str(c) for c in sorted(set(rename_columns.keys()) - set(df.columns)))
+        raise RuntimeError(f"Mortality data missing columns. Missing {missing}.")
+    df = df.rename(columns=rename_columns)
     df["time_upper"] = df.time_lower + 1
     return df

--- a/tests/input_data/configuration/test_build_mortality.py
+++ b/tests/input_data/configuration/test_build_mortality.py
@@ -12,7 +12,7 @@ import pytest
 
 @pytest.mark.parametrize("sexes", [1, 2])
 def test_add_mortality_data(ihme, sexes):
-    ec = make_execution_context(model_version_id=265976, gbd_round_id=5, location_id=6)
+    ec = make_execution_context(model_version_id=265976, gbd_round_id=5, location_id=6, tier=3)
     mc = ModelContext()
     mc.policies = dict(estimate_emr_from_prevalence=0, use_weighted_age_group_midpoints=0)
     mc.input_data.observations = pd.DataFrame(
@@ -30,7 +30,7 @@ def test_add_mortality_data(ihme, sexes):
 
 @pytest.mark.parametrize("sexes", [1, 2])
 def test_add_omega_constraint(ihme, sexes):
-    ec = make_execution_context(model_version_id=265976, gbd_round_id=5, location_id=6)
+    ec = make_execution_context(model_version_id=265976, gbd_round_id=5, location_id=6, tier=3)
     mc = ModelContext()
     mc.policies = dict(estimate_emr_from_prevalence=0, use_weighted_age_group_midpoints=0)
     mc.input_data.observations = pd.DataFrame(
@@ -49,7 +49,7 @@ def test_add_omega_constraint(ihme, sexes):
 def test_omega_constraint_as_effect(ihme, monkeypatch):
     """Assert that the omega constraint is an effect"""
     parent_id = 6
-    ec = make_execution_context(model_version_id=265976, gbd_round_id=5, location_id=parent_id)
+    ec = make_execution_context(model_version_id=265976, gbd_round_id=5, location_id=parent_id, tier=3)
     children = get_descendents(ec, children_only=True)
     assert len(children) > 0
     mc = ModelContext()
@@ -64,7 +64,7 @@ def test_omega_constraint_as_effect(ihme, monkeypatch):
          "hold_out": [0],
          })
 
-    asdr = cascade.input_data.db.mortality.get_age_standardized_death_rate_data(ec)
+    asdr = cascade.input_data.db.mortality.get_frozen_age_standardized_death_rate_data(ec)
     asdr.location_id = parent_id
     child_asdr = [asdr.assign(location_id=child_id) for child_id in children]
     child_asdr.append(asdr)
@@ -75,7 +75,7 @@ def test_omega_constraint_as_effect(ihme, monkeypatch):
     def same_omegas(execution_context):
         return same_means
 
-    monkeypatch.setattr(cascade.input_data.db.mortality, "get_age_standardized_death_rate_data", same_omegas)
+    monkeypatch.setattr(cascade.input_data.db.mortality, "get_frozen_age_standardized_death_rate_data", same_omegas)
 
     add_omega_constraint(mc, ec, 1)
     child_omegas = mc.rates.omega.child_smoothings


### PR DESCRIPTION
Bugfix: We could not see prevalence at birth because a git merge duplicated a line, shadowing the fix, so that line is now gone.

Bugfix: Two new sql queries, to get cause-specific mortality data, were missing a single comma, which caused them to retrieve one-too-few columns and misname them. This was caught by acceptance tests, but we never ran them on the PR b/c github doesn't run them. Would have been caught by Jenkins.

Cleanup: Removed a stray __init__.py file that pycharm put at cascade/src/__init__.py. Bad, Pycharm. Bad.