### PR TITLE
fixed sqlalchemy pool timeout and installation permissions problems

### DIFF
--- a/scripts/automation/install.sh
+++ b/scripts/automation/install.sh
@@ -56,7 +56,7 @@ fi
 # Download the Cascade project from github
 
 CASCADE_HOME=/ihme/code/dismod_at
-CASCADE_DEVELOP_DIR=${CASCADE_HOME}/cascade_develop
+CASCADE_DEVELOP_DIR=${CASCADE_HOME}/clone_for_install
 
 GITHUB="https://github.com/ihmeuw/cascade.git"
 
@@ -95,8 +95,10 @@ if [ "$?" -ne "0" ]; then
     exit 7
 fi
 
-# Install the virtual environment to be the "current" if the tests pass
-(cd "${CASCADE_DEVELOP_DIR}/tests" && pytest)
+# Install the virtual environment to be the "current" if the tests pass.
+# Run testing without writing *.pyc to the __pycache__.
+PYTHONDONTWRITEBYTECODE=1
+(cd "${CASCADE_DEVELOP_DIR}/tests" && python -m pytest -p no:cacheprovider --ihme)
 
 if [ "$?" -eq "0" ]; then
     for softlink in prod dev current
@@ -121,3 +123,10 @@ if ! [ -f "${DISMOD_AT_PATH}" ] ; then
     exit 1
 fi
 echo "The physical path of the DISMOD_AT executable is ${DISMOD_AT_PATH}."
+
+# Generate pyc files for everything before freezing code for other users.
+python -m compileall "${ENV}"
+# Ensure umask is correct for all files touched so another person
+# can install and maintain code.
+chmod -R g+rwX,a+rX "${CASCADE_DEVELOP_DIR}"
+chmod -R g+rwX,a+rX "${ENV}"

--- a/src/cascade/core/db.py
+++ b/src/cascade/core/db.py
@@ -93,6 +93,7 @@ def connection(execution_context=None, database=None):
     connection = ezfuncs.get_connection(database)
     yield connection
     connection.commit()
+    connection.close()
 
 
 def model_version_exists(execution_context):


### PR DESCRIPTION
1. Our database connections were sometimes running out of resources. This fixes the resource problem by adding a single line that closes connections in a central part of our library. The problem showed up during acceptance testing but has not been seen in production, to my knowledge.
2. Installation could fail silently in two ways: a user would be unable to run, or another team member would be unable to complete an install. This PR modifies the installation script to ensure permissions are appropriate for the team and to ensure that it creates a fully-compiled environment for the user.
3. Installation required passing unit tests for an install. This now adds a requirement that acceptance tests run in order to complete an install.

Not a lot of code, but it fixes some things.