### PR TITLE
fixed little bug where --help gave help plus an error message

### DIFF
--- a/src/cascade/executor/argument_parser.py
+++ b/src/cascade/executor/argument_parser.py
@@ -97,11 +97,15 @@ class BaseArgumentParser(ArgumentParser):
         This version instead raises an exception which we can catch,
         use to write an error, and then exit.
         """
-        if message:
+        if status == 0:
+            sys.exit(status)
+
+        elif message:
             super()._print_message(message, sys.stderr)
+            CODELOG.error(message)
+
         else:
             message = "Exiting due to bad arguments: {}".format(sys.argv)
-        CODELOG.error(message)
         raise ArgumentException(message, status)
 
     @staticmethod

--- a/src/cascade/executor/argument_parser.py
+++ b/src/cascade/executor/argument_parser.py
@@ -102,10 +102,11 @@ class BaseArgumentParser(ArgumentParser):
 
         elif message:
             super()._print_message(message, sys.stderr)
-            CODELOG.error(message)
 
         else:
             message = "Exiting due to bad arguments: {}".format(sys.argv)
+
+        CODELOG.error(message)
         raise ArgumentException(message, status)
 
     @staticmethod


### PR DESCRIPTION
Bugfix: Greg pointed out that "dmcascade --help" or "dmcascade -h" is supposed to show command-line options and exit, but it shows command-line options and then an error saying more arguments are required. That was a bug created by code to handle custom exit conditions in the parser. This fixes that code by exiting when we are told to exit.