### PR TITLE
Moved script into installed code and made a setup.py entry point for it

### DIFF
--- a/docs/epiviz/examples.rst
+++ b/docs/epiviz/examples.rst
@@ -1,15 +1,51 @@
 Examples Calling Dmcascade
 ==========================
 
+Retrieve a Settings File from EpiViz-AT
+---------------------------------------
+
+If you want to run and modify a model configured in EpiViz-AT already,
+try downloading the settings file for it. Then edit the settings
+file and run ``dmcascade`` on it, as described below.
+
+These commands are all in ``/ihme/code/dismod_at/bin``.
+First download the file by its model version ID::
+
+    export PATH=$PATH:/ihme/code/dismod_at/bin
+    dmgetsettings --mvid 266870 anx.json
+
+That will create a file called ``anx.json`` in the JSON format.
+It's long, but it looks, in part, like this::
+
+    "rate": [
+        {
+            "default": {
+                "value": {
+                    "density": "gaussian",
+                    "min": 1e-08,
+                    "mean": 0.002,
+                    "max": 0.01,
+                    "std": 0.01
+                },
+    ...
+
+Entries in the settings file are interpreted by code in
+https://github.com/ihmeuw/cascade/blob/develop/src/cascade/input_data/configuration/form.py, which can help understand what to set.
+
+There is a second way to get the settings, which is to get them
+from the web browser while you use EpiViz-AT.
+First run EpiViz-AT.
+Then go to the Developer Console.
+This is a menu option in the web browser.
+Then type ``printSettingsJson()``. Copy to a file what that command prints.
+
+
 Command Line
 ------------
 Run the cascade against the latest model version associated with an meid::
 
+    export PATH=$PATH:/ihme/code/dismod_at/bin
     dmcascade 1989.db --meid 1989
-
-Create a JSON settings file from a model. First run EpiViz.
-Then go to the Developer Console. This is a menu option in the web browser.
-And type ``printSettingsJson()``. Then copy what it prints to a file.
 
 Call from a JSON settings file::
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
             ["dmcsv2db=cascade.executor.no_covariate_main:entry"],
             ["dmres2csv=cascade.executor.model_residuals_main:entry"],
             ["dmsr2csv=cascade.executor.model_results_main:entry"],
+            ["dmgetsettings=cascade.executor.epiviz_json:entry"],
         ]
     },
     scripts=["scripts/dmdismod", "scripts/dmdismodpy"],

--- a/src/cascade/executor/epiviz_json.py
+++ b/src/cascade/executor/epiviz_json.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from textwrap import dedent
 
 from cascade.input_data.db.configuration import load_raw_settings_mvid, load_raw_settings_meid
 from cascade.testing_utilities import make_execution_context
@@ -8,11 +9,19 @@ from cascade.core.log import getLoggers
 CODELOG, MATHLOG = getLoggers(__name__)
 
 
-def main():
-    parser = argparse.ArgumentParser("Download the JSON settings for an epiviz model")
+def entry():
+    parser = argparse.ArgumentParser(dedent("""
+    EpiViz-AT saves all information for any model version into a settings
+    document. This downloads that settings document and saves it as
+    a JSON file that can be edited and run by dmcascade.
+    """))
     parser.add_argument("output_file", type=argparse.FileType("w"))
-    parser.add_argument("--meid", type=int)
-    parser.add_argument("--mvid", type=int)
+    parser.add_argument("--meid", type=int,
+                        help="If you specify a modelable entity ID, this "
+                        "will download the most recent model version ID for "
+                        " that MEID.")
+    parser.add_argument("--mvid", type=int,
+                        help="Model version ID as seen in EpiViz-AT.")
     args = parser.parse_args()
 
     ec = make_execution_context()
@@ -28,4 +37,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    entry()


### PR DESCRIPTION
Katie asked to work with code programmatically and on the cluster. Given two choices: use our current code or modify the JSON, I recommended modifying the JSON.

This PR documents the epiviz_json.py script and installs it with the code so that it is runnable on the cluster. I augmented documentation (of course). Otherwise no changes of note.