### PR TITLE
Feature/create ode additional steps

### DIFF
--- a/src/cascade/dismod/serialize.py
+++ b/src/cascade/dismod/serialize.py
@@ -655,6 +655,7 @@ def make_option_table(context, location_to_node_func):
         "parent_node_id": f"{location_to_node_func(context.parameters.location_id)}",
         "print_level_fixed": "5",
         "ode_step_size": f"{context.parameters.ode_step_size}",
+        "age_avg_split": " ".join([str(aas) for aas in context.parameters.additional_ode_steps]),
         "quasi_fixed": "false",
     }
 

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -173,7 +173,7 @@ def add_omega_constraint(model_context, execution_context, sex_id):
 def add_age_steps(model_context):
     smallest_step = model_context.parameters.ode_step_size
     added = compute_age_steps(smallest_step)
-    model_context.parameters.additional_age_steps = added
+    model_context.parameters.additional_ode_steps = added
 
 
 def compute_age_steps(smallest_step):

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import asyncio
+import math
 from pathlib import Path
 from pprint import pformat
 from bdb import BdbQuit
@@ -169,6 +170,29 @@ def add_omega_constraint(model_context, execution_context, sex_id):
     model_context.input_data.observations = pd.concat([observations, asdr], ignore_index=True, sort=True)
 
 
+def add_age_steps(model_context):
+    """We will add age steps to whatever they have given. The GBD chooses
+    age step sizes of 0, 7 days, 28 days, 1 year, 5 years. These look roughly
+    like a pattern of multiplying by 4, so 1 week, 4 weeks 16 weeks, 64 weeks.
+    Let's play with the numbers to respect that organization.
+
+    This means there are two magic numbers: The smallest step must be less
+    than 7 days, and all steps are 2 times the size of the last step, instead
+    of 4, just to be safe.
+    So an ODE step size of 1 year gives (0.015625, 0.0625, 0.25).
+    An ODE step size of 5 years gives [0.0049, 0.019, 0.078, 0.31, 1.25].
+    """
+    smallest_step = model_context.parameters.ode_step_size
+    minimum_step_size = 7 / 365
+    geometric_growth = 2
+    minimum_step_count = np.log(smallest_step / minimum_step_size) / np.log(geometric_growth)
+    chosen_step_count = math.ceil(minimum_step_count)
+    delta = smallest_step / geometric_growth**chosen_step_count
+    added = np.array([delta * geometric_growth**i for i in range(chosen_step_count)])
+    model_context.parameters.additional_age_steps = added
+    MATHLOG.info(f"Adding ages to ODE integration: {added}")
+
+
 def prepare_data(execution_context, settings):
     if execution_context.parameters.tier == 3:
         freeze_bundle(execution_context, execution_context.parameters.bundle_id)
@@ -280,6 +304,7 @@ def model_context_from_settings(execution_context, settings):
     )
     model_context.average_integrand_cases = cases
 
+    add_age_steps(model_context)
     fixed_effects_from_epiviz(model_context, execution_context, settings)
     random_effects_from_epiviz(model_context, settings)
 

--- a/src/cascade/input_data/configuration/builder.py
+++ b/src/cascade/input_data/configuration/builder.py
@@ -58,6 +58,7 @@ def initial_context_from_epiviz(configuration):
     context.parameters.minimum_meas_cv = configuration.model.minimum_meas_cv
     context.parameters.global_data_eta = configuration.eta.data
     context.parameters.ode_step_size = configuration.model.ode_step_size
+    context.parameters.additional_ode_steps = configuration.model.additional_ode_steps
 
     context.policies = policies_from_settings(configuration)
 

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -212,6 +212,8 @@ class Model(Form):
     constrain_omega = OptionField([0, 1], constructor=int, nullable=False, display="Constrain other cause mortality")
     exclude_data_for_param = ListField(constructor=int, nullable=True, display="Exclude data for parameter")
     ode_step_size = FloatField(display="ODE step size")
+    additional_ode_steps = StringListField(constructor=float, nullable=True,
+                                           display="Advanced additional ODE steps")
     split_sex = OptionField(["most_detailed", "1", "2", "3", "4", "5"], display="Split sex (Being used as Drill Start)")
 
     rate_case = Dummy()

--- a/tests/dismod/test_serialize.py
+++ b/tests/dismod/test_serialize.py
@@ -91,6 +91,7 @@ def base_context(observations, constraints):
     context.parameters.rate_case = "iota_pos_rho_zero"
     context.parameters.location_id = 42
     context.parameters.ode_step_size = 5
+    context.parameters.additional_ode_steps = [0.019, 0.25, 0.5]
     context.parameters.minimum_meas_cv = 0
 
     context.input_data.observations = observations

--- a/tests/executor/test_epiviz_runner.py
+++ b/tests/executor/test_epiviz_runner.py
@@ -1,0 +1,21 @@
+import pytest
+from cascade.executor.epiviz_runner import compute_age_steps
+
+
+@pytest.mark.parametrize("min_step", [
+    (1,), (5,), (0.5,), (0.1,), (10,)
+])
+def test_age_steps(min_step):
+    steps = compute_age_steps(min_step[0])
+    assert steps[0] <= 7 / 365
+    assert 3.5 / 365 <= steps[0]
+    assert steps[-1] < 0.75 * min_step[0]
+    assert steps[-1] > 0.4 * min_step[0]
+
+
+@pytest.mark.parametrize("min_step", [
+    (6 / 365,), (1 / 365,), (0.000001,),
+])
+def test_small_small_step(min_step):
+    steps = compute_age_steps(min_step[0])
+    assert len(steps) == 0


### PR DESCRIPTION
DO NOT MERGE UNTIL NEWER DISMOD-AT THAN 0.7 IS ON THE CLUSTER.
This adds additional ODE integration steps, whether the user specifies them or not.
The modelers and Greg opted for this. It seems safer during early testing to make things a little slower but remove doubt.

It needs dismod that runs. The acceptance test is to run `dmcascade --mvid 266870 --no-upload z.db
Then check that the age steps are in the db and are mentioned in the dismod-at logs.