### PR TITLE
Feature/warnings are errors during unit testing

### DIFF
--- a/scripts/dmdismod
+++ b/scripts/dmdismod
@@ -4,7 +4,7 @@ if [ -e "${SINGULARITY}" ]
 then
     exec singularity exec "${SINGULARITY}" /home/root/prefix/dismod_at/bin/dismod_at $*
 else
-    TARGET_DIR=$(readlink -e $(dirname $1))
+    TARGET_DIR="$( cd "$(dirname $1)" ; pwd -P )"
     TARGET_DB=$(basename $1)
     shift
     set -x

--- a/src/cascade/input_data/emr.py
+++ b/src/cascade/input_data/emr.py
@@ -85,7 +85,8 @@ def _make_interpolators(csmr):
     mean = {}
     stderr = {}
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", module="scipy.interpolate")
+        warnings.filterwarnings("ignore", module="scipy.interpolate",
+                                category=UserWarning, message=r"\s*The coefficient")
         mean["both"] = LSQBivariateSpline(
             csmr.age, csmr.time, csmr["mean"], sorted(csmr.age.unique()), sorted(csmr.time.unique()), kx=1, ky=1
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ def pytest_addoption(parser):
     group = parser.getgroup("cascade")
     group.addoption("--ihme", action="store_true",
                     help="run functions requiring access to central comp and Dismod-AT")
+    group.addoption("--signals", action="store_true",
+                    help="run functions requiring access to central comp and Dismod-AT")
 
 
 @pytest.fixture
@@ -44,3 +46,19 @@ class IhmeDbFuncArg:
             pytest.skip(f"specify --ihme to run tests requiring Central Comp databases")
 
         cascade.core.db.BLOCK_SHARED_FUNCTION_ACCESS = False
+
+
+@pytest.fixture
+def signals(request):
+    return SignalQuietArg(request)
+
+
+class SignalQuietArg:
+    """
+    Some tests kill processes with UNIX signals that, on the Mac so far,
+    cause the OS to try to notify Apple of a problem. This flag turns
+    off those tests.
+    """
+    def __init__(self, request):
+        if request.config.getoption("signals"):
+            pytest.skip(f"specify --signals if using UNIX signals can stop pytest")

--- a/tests/executor/test_dismod_runner.py
+++ b/tests/executor/test_dismod_runner.py
@@ -45,7 +45,7 @@ def test_dmchat_low_priority(dmchat, caplog):
     assert err == "".join(["err" + os.linesep] * 2)
 
 
-def test_dmchat_nonzero(dmchat):
+def test_dmchat_nonzero(dmchat, signals):
     with pytest.raises(Exception):
         dr.run_and_watch([dmchat, "1", "0", "7"], True, 2)
 

--- a/tests/model/test_operations.py
+++ b/tests/model/test_operations.py
@@ -54,8 +54,8 @@ def make_grid_priors(ages, times, grid_priors, hyper_priors, smooth_id=7):
                     hyper_priors["value"], hyper_priors["dage"], hyper_priors["dtime"], 0],
     ))
     # Make the last one const. If tests want to make a point const, use prior_id=6.
-    prior.loc[6]["lower"] = 0.5
-    prior.loc[6]["upper"] = 0.5
+    prior.loc[6, "lower"] = 0.5
+    prior.loc[6, "upper"] = 0.5
 
     smooth = pd.DataFrame(dict(
         smooth_id=[smooth_id],
@@ -109,9 +109,8 @@ def vars_from_priors(dismod_file):
             prior = dismod_file.prior.query("prior_id == @odd_id")
             if (prior["upper"] > prior["lower"]).bool():
                 grid_vars = grid_vars.append(pd.DataFrame(
-                    [[f"mulstd_{odd_hyper}"]],
-                    columns=["var_type"],
-                ))
+                    {"var_type": [f"mulstd_{odd_hyper}"]},
+                ), sort=False)
     dismod_file.var = grid_vars.assign(
         var_id=list(range(len(grid_vars))),
         smooth_id=7,

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ envlist = py36,docs
 [pytest]
 xfail_strict = true
 testpaths = tests
+# invalid escape sequence = using latex in non-raw docstrings, by libraries.
+# numpy.ufunc = mismatch between compiled and machine-specific somehow.
+# can't resolve = library using dynamic loading, but it works fine.
 filterwarnings =
     error::Warning
     ignore:invalid escape sequence:DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,11 @@ envlist = py36,docs
 [pytest]
 xfail_strict = true
 testpaths = tests
+filterwarnings =
+    error::Warning
+    ignore:invalid escape sequence:DeprecationWarning
+    ignore:numpy.ufunc size changed
+    ignore:can't resolve package from __spec__:ImportWarning
 [testenv]
 extras = testing
 commands = py.test


### PR DESCRIPTION
1. For unit tests, this turns on a flag to make all warnings errors. Warnings are a particular class of messages in Python, coming from the warnings module, that are used by many libraries to indicate future incompatibility or current suspicious behavior. This also suppresses certain known warnings. The result is that unit tests now pass "full green," instead of yellow, as before.
2. Unit testing on the Mac failed because some of the tests intentionally kill Dismod in such a way that the operating system offers to tell Apple that the application crashed (with a SIGINT). This adds a fixture that can be used to turn _off_ those tests, called `--signals`.
3. Our wrapper script for Dismod-AT let's you call Dismod-AT from the command line both on the cluster (where it is installed under Singularity) or on your laptop (using Docker) with the same command. The wrapper was failing on a laptop with a different version of Bash (my Mac), so there is a one-line fix for that.