### PR TITLE
Feature/load to tier three as needed

### DIFF
--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -231,11 +231,11 @@ def prepare_data(execution_context, settings):
             tier=execution_context.parameters.tier
         )
 
-    location_and_descendents = get_descendants(execution_context, include_parent=True)  # noqa: F841
+    location_and_descendants = get_descendants(execution_context, include_parent=True)  # noqa: F841
 
-    bundle = bundle.query("location_id in @location_and_descendents")
+    bundle = bundle.query("location_id in @location_and_descendants")
     location_id = execution_context.parameters.parent_location_id
-    MATHLOG.info(f"Filtering bundle to location {location_id} and its descendents. {len(bundle)} rows remaining.")
+    MATHLOG.info(f"Filtering bundle to location {location_id} and its descendants. {len(bundle)} rows remaining.")
 
     stderr_mask = bundle.standard_error > 0
     if (~stderr_mask).sum() > 0:

--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -24,7 +24,7 @@ from cascade.input_data.db.demographics import age_groups_to_ranges
 from cascade.testing_utilities import make_execution_context
 from cascade.input_data.db.configuration import load_settings
 from cascade.input_data.db.csmr import load_csmr_to_t3, get_csmr_data
-from cascade.input_data.db.locations import get_descendents, location_id_from_location_and_level
+from cascade.input_data.db.locations import get_descendants, location_id_from_location_and_level
 from cascade.input_data.db.asdr import load_asdr_to_t3, get_asdr_data
 from cascade.input_data.db.mortality import (
     get_frozen_cause_specific_mortality_data,
@@ -159,7 +159,7 @@ def add_omega_constraint(model_context, execution_context, sex_id):
     model_context.rates.omega.parent_smooth = build_constraint(parent_asdr)
     MATHLOG.debug(f"Add {parent_asdr.shape[0]} omega constraints from age-standardized death rate data to the parent.")
 
-    children = get_descendents(execution_context, children_only=True)  # noqa: F841
+    children = get_descendants(execution_context, children_only=True)  # noqa: F841
     children_asdr = asdr.query("node_id in @children")
     # Transform the children to be the random effect for the rate.
     parent_value = parent_asdr[["age_lower", "time_lower", "mean"]].rename({"mean": "parent_mean"}, axis=1)
@@ -231,7 +231,7 @@ def prepare_data(execution_context, settings):
             tier=execution_context.parameters.tier
         )
 
-    location_and_descendents = get_descendents(execution_context, include_parent=True)  # noqa: F841
+    location_and_descendents = get_descendants(execution_context, include_parent=True)  # noqa: F841
 
     bundle = bundle.query("location_id in @location_and_descendents")
     location_id = execution_context.parameters.parent_location_id

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from cascade.core.db import cursor, db_queries
 from cascade.input_data.db import AGE_GROUP_SET_ID
-from cascade.input_data.db.locations import get_descendents
+from cascade.input_data.db.locations import get_descendants
 
 
 from cascade.core.log import getLoggers
@@ -37,7 +37,7 @@ def get_asdr_data(execution_context):
     age_group_ids = demo_dict["age_group_id"]
     sex_ids = demo_dict["sex_id"]
 
-    location_and_children = get_descendents(execution_context, children_only=True, include_parent=True)
+    location_and_children = get_descendants(execution_context, children_only=True, include_parent=True)
 
     asdr = db_queries.get_envelope(
         location_id=location_and_children,

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -19,25 +19,22 @@ def _asdr_in_t3(execution_context):
     model_version_id = execution_context.parameters.model_version_id
 
     query = """
-    SELECT exists(
-             SELECT * FROM epi.t3_model_version_asdr
-             WHERE model_version_id = %(model_version_id)s
-    )
+    SELECT DISTINCT location_id
+    FROM epi.t3_model_version_asdr
+    WHERE model_version_id = %(model_version_id)s
     """
     with cursor(execution_context) as c:
         c.execute(query, args={"model_version_id": model_version_id})
-        exists = c.fetchone()[0]
+        location_rows = c.fetchall()
 
-    return exists == 1
+    return [row[0] for row in location_rows]
 
 
-def get_asdr_data(execution_context):
+def get_asdr_data(execution_context, location_and_children):
 
     demo_dict = db_queries.get_demographics(gbd_team="epi", gbd_round_id=execution_context.parameters.gbd_round_id)
     age_group_ids = demo_dict["age_group_id"]
     sex_ids = demo_dict["sex_id"]
-
-    location_and_children = get_descendants(execution_context, children_only=True, include_parent=True)
 
     asdr = db_queries.get_envelope(
         location_id=location_and_children,
@@ -97,11 +94,8 @@ def _upload_asdr_data_to_tier_3(execution_context, cursor, model_version_id, asd
         "age_upper",
         "age_lower",
     ]
-
     asdr_data = asdr_data[ordered_cols]
-
     cursor.executemany(insert_query, asdr_data.values.tolist())
-
     CODELOG.debug(f"uploaded {len(asdr_data)} lines of asdr data")
 
 
@@ -111,24 +105,24 @@ def load_asdr_to_t3(execution_context) -> bool:
     """
 
     model_version_id = execution_context.parameters.model_version_id
-
     database = execution_context.parameters.database
-
-    if _asdr_in_t3(execution_context):
-        CODELOG.info(
-            f"""asdr data for model_version_id {model_version_id}
-            on '{database}' already exists, doing nothing."""
-        )
-        return False
-    else:
+    location_and_children = get_descendants(execution_context, children_only=True, include_parent=True)
+    locations_with_asdr_in_t3 = _asdr_in_t3(execution_context)
+    missing_from_t3 = set(location_and_children) - set(locations_with_asdr_in_t3)
+    if missing_from_t3:
         CODELOG.info(
             f"""Uploading asdr data for model_version_id
             {model_version_id} on '{database}'"""
         )
-
-        asdr_data = get_asdr_data(execution_context)
+        asdr_data = get_asdr_data(execution_context, location_and_children)
 
         with cursor(execution_context) as c:
             _upload_asdr_data_to_tier_3(execution_context, c, model_version_id, asdr_data)
 
         return True
+    else:
+        CODELOG.info(
+            f"""asdr data for model_version_id {model_version_id}
+            on '{database}' already exists, doing nothing."""
+        )
+        return False

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -114,7 +114,7 @@ def load_asdr_to_t3(execution_context) -> bool:
             f"""Uploading asdr data for model_version_id
             {model_version_id} on '{database}'"""
         )
-        asdr_data = get_asdr_data(execution_context, location_and_children)
+        asdr_data = get_asdr_data(execution_context, list(missing_from_t3))
 
         with cursor(execution_context) as c:
             _upload_asdr_data_to_tier_3(execution_context, c, model_version_id, asdr_data)

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from cascade.core.db import cursor, db_queries
 from cascade.input_data.db import METRIC_IDS, MEASURE_IDS, GBDDataError
-import cascade.input_data.db.locations
+from cascade.input_data.db.locations import get_descendants
 
 
 from cascade.core import getLoggers
@@ -126,8 +126,7 @@ def load_csmr_to_t3(execution_context) -> bool:
     Upload to t3_model_version_csmr if it's not already there.
     """
     model_version_id = execution_context.parameters.model_version_id
-    location_and_children = cascade.input_data.db.locations.get_descendants(
-        execution_context, children_only=True, include_parent=True)
+    location_and_children = get_descendants(execution_context, children_only=True, include_parent=True)
     database = execution_context.parameters.database
     locations_with_data_in_t3 = _csmr_in_t3(execution_context, execution_context.parameters.model_version_id)
     csmr_not_in_t3 = set(location_and_children) - set(locations_with_data_in_t3)

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -133,7 +133,7 @@ def load_csmr_to_t3(execution_context) -> bool:
     if csmr_not_in_t3:
         CODELOG.info(f"Uploading csmr data for model_version_id {model_version_id} on '{database}'")
 
-        csmr_data = get_csmr_data(execution_context, location_and_children)
+        csmr_data = get_csmr_data(execution_context, list(csmr_not_in_t3))
 
         with cursor(execution_context) as c:
             _upload_csmr_data_to_tier_3(c, model_version_id, csmr_data)

--- a/src/cascade/input_data/db/locations.py
+++ b/src/cascade/input_data/db/locations.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 from cascade.core.db import db_queries
-from cascade.core.log import getLoggers
+from cascade.core import getLoggers
 
 CODELOG, MATHLOG = getLoggers(__name__)
 
@@ -35,7 +35,7 @@ def location_hierarchy(execution_context):
     return G
 
 
-def get_descendents(execution_context, children_only=False, include_parent=False):
+def get_descendants(execution_context, children_only=False, include_parent=False):
     """
     Retrieves a parent and direct children, or all descendants, or not the
     parent.

--- a/tests/core/test_cascade_plan.py
+++ b/tests/core/test_cascade_plan.py
@@ -12,7 +12,7 @@ def test_create(ihme):
         policies=dict(),
     )
     c = CascadePlan.from_epiviz_configuration(ec, settings)
-    assert len(c.task_graph.nodes) == 2
+    assert len(c.task_graph.nodes) == 1
     print(nx.to_edgelist(c.task_graph))
 
 
@@ -62,4 +62,6 @@ def test_iterate_tasks(ihme):
         assert t[0] > last  # Only true in a drill
         last = t[0]
         cnt += 1
-    assert cnt == 3
+    # It would be 3, but this has been downgraded to use 1 if you
+    # have split_sex
+    assert cnt == 1

--- a/tests/input_data/configuration/test_build_mortality.py
+++ b/tests/input_data/configuration/test_build_mortality.py
@@ -3,7 +3,7 @@ from cascade.testing_utilities import make_execution_context
 from cascade.core.context import ModelContext
 import cascade.input_data.db.mortality
 from cascade.model.priors import Constant
-from cascade.input_data.db.locations import get_descendents
+from cascade.input_data.db.locations import get_descendants
 
 import numpy as np
 import pandas as pd
@@ -51,7 +51,7 @@ def test_omega_constraint_as_effect(ihme, monkeypatch):
     """Assert that the omega constraint is an effect"""
     parent_id = 6
     ec = make_execution_context(model_version_id=265976, gbd_round_id=5, parent_location_id=parent_id, tier=3)
-    children = get_descendents(ec, children_only=True)
+    children = get_descendants(ec, children_only=True)
     assert len(children) > 0
     mc = ModelContext()
     mc.parameters.parent_location_id = parent_id

--- a/tests/input_data/db/test_asdr.py
+++ b/tests/input_data/db/test_asdr.py
@@ -4,7 +4,10 @@ from cascade.input_data.db.asdr import load_asdr_to_t3
 def test_load_asdr_to_t3_did_upload(mock_execution_context, mock_database_access, mocker):
 
     mock_check = mocker.patch("cascade.input_data.db.asdr._asdr_in_t3")
-    mock_check.return_value = False
+    mock_check.return_value = [19]
+
+    mock_location = mocker.patch("cascade.input_data.db.asdr.get_descendants")
+    mock_location.return_value = [248]
 
     mock_get_asdr_data = mocker.patch("cascade.input_data.db.asdr.get_asdr_data")
     mock_upload_asdr_data = mocker.patch("cascade.input_data.db.asdr._upload_asdr_data_to_tier_3")
@@ -20,7 +23,10 @@ def test_load_asdr_to_t3_did_upload(mock_execution_context, mock_database_access
 def test_load_asdr_to_t3_no_upload(mock_execution_context, mock_database_access, mocker):
 
     mock_check = mocker.patch("cascade.input_data.db.asdr._asdr_in_t3")
-    mock_check.return_value = True
+    mock_check.return_value = [248]
+
+    mock_location = mocker.patch("cascade.input_data.db.asdr.get_descendants")
+    mock_location.return_value = [248]
 
     mock_upload_asdr_data = mocker.patch("cascade.input_data.db.asdr._upload_asdr_data_to_tier_3")
 

--- a/tests/input_data/db/test_csmr.py
+++ b/tests/input_data/db/test_csmr.py
@@ -1,10 +1,14 @@
-from cascade.input_data.db.csmr import load_csmr_to_t3
+from cascade.testing_utilities import make_execution_context
+from cascade.input_data.db.csmr import load_csmr_to_t3, _csmr_in_t3
 
 
 def test_load_csmr_to_t3_did_upload(mock_execution_context, mock_database_access, mocker):
 
     mock_check = mocker.patch("cascade.input_data.db.csmr._csmr_in_t3")
-    mock_check.return_value = False
+    mock_check.return_value = [19]
+
+    mock_location = mocker.patch("cascade.input_data.db.locations.get_descendants")
+    mock_location.return_value = [248]
 
     mock_get_csmr_data = mocker.patch("cascade.input_data.db.csmr.get_csmr_data")
     mock_upload_csmr_data = mocker.patch("cascade.input_data.db.csmr._upload_csmr_data_to_tier_3")
@@ -19,11 +23,24 @@ def test_load_csmr_to_t3_did_upload(mock_execution_context, mock_database_access
 
 def test_load_csmr_to_t3_no_upload(mock_execution_context, mock_database_access, mocker):
 
+    mock_location = mocker.patch("cascade.input_data.db.locations.get_descendants")
+    mock_location.return_value = [248]
+
     mock_check = mocker.patch("cascade.input_data.db.csmr._csmr_in_t3")
-    mock_check.return_value = True
+    mock_check.return_value = [248]
 
     mock_upload_csmr_data = mocker.patch("cascade.input_data.db.csmr._upload_csmr_data_to_tier_3")
 
     assert not load_csmr_to_t3(mock_execution_context)
 
     assert not mock_upload_csmr_data.called
+
+
+def test_csmr_check_in_t3_by_location(ihme):
+    ec = make_execution_context()
+    # This should be a list of location ids.
+    locs = _csmr_in_t3(ec, 267245)
+    assert locs == [80]
+    # If the model version id doesn't exist, return an empty list.
+    locs = _csmr_in_t3(ec, -3)
+    assert not locs

--- a/tests/input_data/db/test_csmr.py
+++ b/tests/input_data/db/test_csmr.py
@@ -7,7 +7,7 @@ def test_load_csmr_to_t3_did_upload(mock_execution_context, mock_database_access
     mock_check = mocker.patch("cascade.input_data.db.csmr._csmr_in_t3")
     mock_check.return_value = [19]
 
-    mock_location = mocker.patch("cascade.input_data.db.locations.get_descendants")
+    mock_location = mocker.patch("cascade.input_data.db.csmr.get_descendants")
     mock_location.return_value = [248]
 
     mock_get_csmr_data = mocker.patch("cascade.input_data.db.csmr.get_csmr_data")
@@ -23,7 +23,7 @@ def test_load_csmr_to_t3_did_upload(mock_execution_context, mock_database_access
 
 def test_load_csmr_to_t3_no_upload(mock_execution_context, mock_database_access, mocker):
 
-    mock_location = mocker.patch("cascade.input_data.db.locations.get_descendants")
+    mock_location = mocker.patch("cascade.input_data.db.csmr.get_descendants")
     mock_location.return_value = [248]
 
     mock_check = mocker.patch("cascade.input_data.db.csmr._csmr_in_t3")

--- a/tests/input_data/db/test_location.py
+++ b/tests/input_data/db/test_location.py
@@ -2,7 +2,7 @@ import networkx as nx
 import pytest
 
 from cascade.testing_utilities import make_execution_context
-from cascade.input_data.db.locations import get_descendents, location_id_from_location_and_level, location_hierarchy
+from cascade.input_data.db.locations import get_descendants, location_id_from_location_and_level, location_hierarchy
 
 
 class MockLocation:
@@ -64,35 +64,35 @@ def mock_locations(mocker):
 def test_get_descendents__all_descendents(mock_locations):
     ec = make_execution_context(parent_location_id=0)
     # descendents of global
-    assert set(get_descendents(ec)) == set(range(1, 8))
+    assert set(get_descendants(ec)) == set(range(1, 8))
 
     ec = make_execution_context(parent_location_id=7)
     # descendents of a leaf (ie. nothing)
-    assert set(get_descendents(ec)) == set()
+    assert set(get_descendants(ec)) == set()
 
 
 def test_get_descendents__only_children(mock_locations):
     ec = make_execution_context(parent_location_id=0)
     # children of global
-    assert set(get_descendents(ec, children_only=True)) == {1, 2}
+    assert set(get_descendants(ec, children_only=True)) == {1, 2}
 
     ec = make_execution_context(parent_location_id=5)
     # children of a leaf
-    assert set(get_descendents(ec, children_only=True)) == set()
+    assert set(get_descendants(ec, children_only=True)) == set()
 
 
 def test_get_descendents__include_parent(mock_locations):
     ec = make_execution_context(parent_location_id=0)
     # descendents of global and iteslf
-    assert set(get_descendents(ec, include_parent=True)) == set(range(0, 8))
+    assert set(get_descendants(ec, include_parent=True)) == set(range(0, 8))
     # children of global and iteslf
-    assert set(get_descendents(ec, children_only=True, include_parent=True)) == {0, 1, 2}
+    assert set(get_descendants(ec, children_only=True, include_parent=True)) == {0, 1, 2}
 
     ec = make_execution_context(parent_location_id=5)
     # descendents of a leaf and itself
-    assert set(get_descendents(ec, include_parent=True, children_only=True)) == {5}
+    assert set(get_descendants(ec, include_parent=True, children_only=True)) == {5}
     # children of a leaf and itself
-    assert set(get_descendents(ec, include_parent=True, children_only=True)) == {5}
+    assert set(get_descendants(ec, include_parent=True, children_only=True)) == {5}
 
 
 def test_location_id_from_location_and_level__happy_path(mock_locations):

--- a/tests/input_data/db/test_location.py
+++ b/tests/input_data/db/test_location.py
@@ -61,17 +61,17 @@ def mock_locations(mocker):
     locations.return_value = G
 
 
-def test_get_descendents__all_descendents(mock_locations):
+def test_get_descendants__all_descendants(mock_locations):
     ec = make_execution_context(parent_location_id=0)
-    # descendents of global
+    # descendants of global
     assert set(get_descendants(ec)) == set(range(1, 8))
 
     ec = make_execution_context(parent_location_id=7)
-    # descendents of a leaf (ie. nothing)
+    # descendants of a leaf (ie. nothing)
     assert set(get_descendants(ec)) == set()
 
 
-def test_get_descendents__only_children(mock_locations):
+def test_get_descendants__only_children(mock_locations):
     ec = make_execution_context(parent_location_id=0)
     # children of global
     assert set(get_descendants(ec, children_only=True)) == {1, 2}
@@ -81,15 +81,15 @@ def test_get_descendents__only_children(mock_locations):
     assert set(get_descendants(ec, children_only=True)) == set()
 
 
-def test_get_descendents__include_parent(mock_locations):
+def test_get_descendants__include_parent(mock_locations):
     ec = make_execution_context(parent_location_id=0)
-    # descendents of global and iteslf
+    # descendants of global and iteslf
     assert set(get_descendants(ec, include_parent=True)) == set(range(0, 8))
     # children of global and iteslf
     assert set(get_descendants(ec, children_only=True, include_parent=True)) == {0, 1, 2}
 
     ec = make_execution_context(parent_location_id=5)
-    # descendents of a leaf and itself
+    # descendants of a leaf and itself
     assert set(get_descendants(ec, include_parent=True, children_only=True)) == {5}
     # children of a leaf and itself
     assert set(get_descendants(ec, include_parent=True, children_only=True)) == {5}


### PR DESCRIPTION
1. Renamed descendent to descendant. This was the most important contribution of this PR.
2. ASDR and CSMR now check, not that any data is in tier 3, but that any data from the locations in this location and its descendants, are in tier 3. Then it conditionally loads data from locations which are missing data.
3. I also deleted blank lines, because I'm a professional, and professionals hate whitespace.