### PR TITLE
changed to settings error

### DIFF
--- a/src/cascade/executor/epiviz_runner.py
+++ b/src/cascade/executor/epiviz_runner.py
@@ -527,7 +527,7 @@ def main(args):
     settings = load_settings(ec, args.meid, args.mvid, args.settings_file)
 
     if settings.model.drill != "drill":
-        raise NotImplementedError("Only 'drill' mode is currently supported")
+        raise SettingsError("Only 'drill' mode is currently supported")
 
     add_settings_to_execution_context(ec, settings)
     plan = CascadePlan.from_epiviz_configuration(ec, settings)


### PR DESCRIPTION
Liane saw an error that the setting for "drill" was incorrect. This is something she could fix, but we classified the error as a code error. This changes the exception type to something that will print for her.