### PR TITLE
bugfix/ Cascade logs keep getting deleted

### DIFF
--- a/src/cascade/executor/argument_parser.py
+++ b/src/cascade/executor/argument_parser.py
@@ -143,7 +143,7 @@ class BaseArgumentParser(ArgumentParser):
 
     @staticmethod
     def _logging_configure_root_log(code_log_dir, level):
-        user_code_dir = code_log_dir / getuser() / "cascade"
+        user_code_dir = code_log_dir / getuser() / "dismod"
         try:
             user_code_dir_exists = user_code_dir.exists()
         except (OSError, PermissionError) as uce:

--- a/tests/dismod/test_serialize.py
+++ b/tests/dismod/test_serialize.py
@@ -266,6 +266,16 @@ def test_make_node_table(base_context, mock_get_location_hierarchy_from_gbd):
     assert_frame_equal(node_table, expected, check_like=True)
 
 
+def test_live_locations_node_table(ihme):
+    """Ensure Global has no parent."""
+    ec = make_execution_context(gbd_round_id=5)
+    node_table, location_to_node_func = make_node_table(ec)
+    first_row = node_table.iloc[0]
+    assert np.isnan(first_row.parent)
+    assert first_row.c_location_id == 1
+    assert first_row.node_id == 0
+
+
 def test_make_data_table(base_context, mock_get_location_hierarchy_from_gbd):
     node_table, _ = make_node_table(base_context)
     renames = dict(x_sex="x_0")

--- a/tests/executor/test_argparse.py
+++ b/tests/executor/test_argparse.py
@@ -84,7 +84,7 @@ def test_code_log(tmpdir):
 
     os.umask(previous_umask)
 
-    base_dir = tmp_dir / getpass.getuser() / "cascade"
+    base_dir = tmp_dir / getpass.getuser() / "dismod"
     logs = list(base_dir.glob("*.log"))
     print(logs)
     code_log = logs[0].read_text().splitlines()
@@ -109,7 +109,7 @@ def test_reduced_code_log(tmpdir):
     codelog.error("errorhumc")
     close_all_handlers()
 
-    base_dir = tmp_dir / getpass.getuser() / "cascade"
+    base_dir = tmp_dir / getpass.getuser() / "dismod"
     code_log = next(base_dir.glob("*.log")).read_text().splitlines()
     assert any(in_line.strip().endswith("warningfoc") for in_line in code_log)
     assert any(in_line.strip().endswith("errorhumc") for in_line in code_log)


### PR DESCRIPTION
The cascade logs are deleted every 4 hours. If we put them into a "dismod" directory, they won't be. This is on this PR because I can't see logs, again, to debug the global locations.

I'd like to push this to the cluster for the one-line fix.