### PR TITLE
Feature/execution context locates files

### DIFF
--- a/docs/epiviz/dmcascade.rst
+++ b/docs/epiviz/dmcascade.rst
@@ -7,16 +7,95 @@ Command-line EpiViz-AT
 Run the cascade against the latest model version associated with an meid::
 
     export PATH=$PATH:/ihme/code/dismod_at/bin
-    dmcascade 1989.db --meid 1989
+    dismodel --meid 1989
 
+This will create subdirectories of the current directory that look like
+``./meid/mvid/1/location_id``. The 1 is a directory that splits locations
+into sets of 100, so numbers of files within a directory don't get out of hand.
 Call from a JSON settings file::
 
-    dmcascade 1989.db --settings-file 1989.json
+    dismodel --settings-file 1989.json
 
 Run from bundle data on disk rather than loading it from the database::
 
-    dmcascade 1989.db --settings-file 1989.json --bundle-file inputs.csv --bundle-study-covariates-file input_covs.csv
+    dmcascade --settings-file 1989.json --bundle-file inputs.csv --bundle-study-covariates-file input_covs.csv
 
 The bundle file must have the following columns: seq (id used to align with the study covariates data), measure, mean, sex_id, standard_error, hold_out, age_lower, age_upper, time_lower, time_upper, location_id
 
 The study covariates file must have the following columns: seq (must match the id in the bundle file), study_covariate_id
+
+
+**Dismodel**
+
+.. program:: dismodel
+
+.. option:: -h, --help
+
+    Prints help
+
+.. option:: -v, --verbose
+
+    Increases logging to stderr
+
+.. option:: -q, --quiet
+
+    Decreases logging
+
+.. option:: --logmod LOGMOD
+
+    Given a module named LOGMOD, sets its logging level using ``modlevel``
+
+.. option:: --modlevel LOGLEVEL
+
+    LOGLEVEL is one of debug, warning, info, error, for the modules
+    listed by ``logmod``.
+
+.. option:: --mvid MVID
+
+    MVID is a model version ID to retrieve from databases.
+
+.. option:: --meid MODELABLE_ENTITY_ID
+
+    Read the latest settings for this modelable entity ID. This will get
+    a specific model version ID.
+
+.. option:: --settings-file SETTINGS
+
+    SETTINGS is a JSON-formatted file that comes from downloading
+    settings from the EpiViz-AT UI or by using the ``dmgetsettings`` tool.
+
+.. option:: --base-directory DIRECTORY
+
+    File writing and reading is relative to this directory.
+
+.. option:: --no-upload
+
+    Do the calculation, make the files, but don't save it to the databases
+    that infrastructure uses.
+
+.. option:: --db-only
+
+    Download settings and data, build the Dismod-AT db file for the initial
+    fit, but don't do the fit.
+
+.. option:: --infrastructure
+
+    If this flag is used, then use the modelable entity id and model version
+    id to create a nested directory structure under the base directory.
+
+.. option:: --skip-cache
+
+    Download all data from the databases, instead of going to tier 3, which
+    is a version stored in order to ensure repeatable runs. This flag
+    also turns off creation of a tier 3 copy of data.
+
+.. option:: --num-processes NUM_PROCESSES
+
+    NUM_PROCESSES is an integer number of subprocesses to use when calling
+    Dismod-AT fit simulate, which generates draws. The number of processes
+    should fit within the computer's memory for the given model.
+
+.. option:: --pdb
+
+    If the program encounters an error then it will drop into a debugger
+    if this flag is given.

--- a/src/cascade/core/context.py
+++ b/src/cascade/core/context.py
@@ -1,10 +1,13 @@
-from rocketsonde.core import Probe, basic_metric
-from cascade.core.parameters import ParameterProperty
-from cascade.core.input_data import InputData
-from cascade.model.rates import Rate
-from cascade.dismod.constants import IntegrandEnum
+from pathlib import Path
 
+from rocketsonde.core import Probe, basic_metric
+
+from cascade.core.input_data import InputData
 from cascade.core.log import getLoggers
+from cascade.core.parameters import ParameterProperty
+from cascade.dismod.constants import IntegrandEnum
+from cascade.model.rates import Rate
+
 CODELOG, MATHLOG = getLoggers(__name__)
 
 
@@ -21,6 +24,9 @@ class ExecutionContext:
     def __init__(self):
         self.dismodfile = None
         self.resource_monitor = Probe(basic_metric)
+
+    def fit_db_path(self):
+        return Path("subsession.db")
 
 
 class _ModelParameters:

--- a/src/cascade/core/context.py
+++ b/src/cascade/core/context.py
@@ -25,8 +25,42 @@ class ExecutionContext:
         self.dismodfile = None
         self.resource_monitor = Probe(basic_metric)
 
-    def fit_db_path(self):
-        return Path("subsession.db")
+    def db_path(self, location_id):
+        """
+
+        Args:
+            location_id (int):
+
+        Returns:
+            Path: directory in which to write. May not exist.
+        """
+        if hasattr(self.parameters, "organizational_mode") and self.parameters.organizational_mode == "infrastructure":
+            return self.model_base_directory(location_id)
+        else:
+            if hasattr(self.parameters, "base_directory") and self.parameters.base_directory:
+                return (Path(self.parameters.base_directory) / str(location_id)).expanduser()
+            else:
+                return (Path(".") / str(location_id)).expanduser()
+
+    def model_base_directory(self, location_id):
+        if hasattr(self.parameters, "base_directory") and self.parameters.base_directory:
+            base_directory = Path(self.parameters.base_directory)
+        else:
+            base_directory = Path(".")
+
+        if hasattr(self.parameters, "modelable_entity_id") and self.parameters.modelable_entity_id:
+            subdir = base_directory / str(self.parameters.modelable_entity_id)
+        else:
+            subdir = base_directory / "mvid"
+
+        if hasattr(self.parameters, "model_version_id") and self.parameters.model_version_id:
+            with_mvid = subdir / str(self.parameters.model_version_id)
+        else:
+            with_mvid = subdir
+
+        group_locations = location_id // 100
+        with_loc = with_mvid / str(group_locations) / str(location_id)
+        return with_loc.expanduser()
 
 
 class _ModelParameters:

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -217,10 +217,12 @@ def compute_location(execution_context, local_settings, input_data, model):
     Returns:
         The fit and draws.
     """
+    base_path = execution_context.db_path(local_settings.parent_location_id)
+    base_path.mkdir(parents=True, exist_ok=True)
     session = Session(
         locations=input_data.locations_df,
         parent_location=model.location_id,
-        filename=execution_context.fit_db_path()
+        filename=base_path / "fit.db"
     )
     session.set_option(**make_options(local_settings.settings))
     begin = timer()
@@ -231,7 +233,7 @@ def compute_location(execution_context, local_settings, input_data, model):
         session.setup_model_for_fit(model, input_data.observations)
         return None, None
     CODELOG.info(f"fit {timer() - begin} success {fit_result.success}")
-    draws = make_draws(model, input_data, fit_result.fit, local_settings)
+    draws = make_draws(execution_context, model, input_data, fit_result.fit, local_settings)
     return fit_result.fit, draws
 
 
@@ -239,12 +241,14 @@ def save_outputs(computed_fit, draws, execution_context, local_settings):
     return None
 
 
-def make_draws(model, input_data, max_fit, local_settings):
+def make_draws(execution_context, model, input_data, max_fit, local_settings):
+    base_path = execution_context.db_path(local_settings.parent_location_id)
+    base_path.mkdir(parents=True, exist_ok=True)
     draw_cnt = local_settings.number_of_fixed_effect_samples
     session = Session(
         locations=input_data.locations_df,
         parent_location=model.location_id,
-        filename="simulate.db"
+        filename=base_path / "simulate.db"
     )
     session.set_option(**make_options(local_settings.settings))
     simulate_result = session.simulate(model, input_data.observations, max_fit, draw_cnt)
@@ -254,11 +258,11 @@ def make_draws(model, input_data, max_fit, local_settings):
         sim_model, sim_data = simulate_result.simulation(draw_idx)
         # let's start a new session because the simulation results are associated
         # with a session and running a new fit will delete them.
-        fit_file = f"simulate{draw_idx}.db"
+        fit_file = f"simulate_{draw_idx}.db"
         sim_session = Session(
             locations=input_data.locations_df,
             parent_location=model.location_id,
-            filename=fit_file
+            filename=base_path / fit_file
         )
         sim_session.set_option(**make_options(local_settings.settings))
         begin = timer()

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -213,11 +213,10 @@ def compute_location(execution_context, local_settings, input_data, model):
     Returns:
         The fit and draws.
     """
-
     session = Session(
         locations=input_data.locations_df,
         parent_location=model.location_id,
-        filename="subsession.db"
+        filename=execution_context.fit_db_path()
     )
     session.set_option(**make_options(local_settings.settings))
     begin = timer()

--- a/tests/core/test_execution_context.py
+++ b/tests/core/test_execution_context.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from cascade.core.context import ExecutionContext
 
 
@@ -5,12 +9,37 @@ def test_make_execution_context():
     ec = ExecutionContext()
     ec.parameters = {"database": "dismod-at-dev", "bundle_database": "epi"}
     assert ec.parameters.database == "dismod-at-dev"
+    assert hasattr(ec.parameters, "database")
 
 
-def test_execution_context_file_interface(tmp_path):
+@pytest.mark.parametrize("meid,mvid,expected", [
+    (4321, 267737, "./4321/267737/1/120"),
+    (None, 267737, "./mvid/267737/1/120"),
+])
+def test_execution_context_file_interface(tmp_path, meid, mvid, expected):
     ec = ExecutionContext()
     ec.parameters = {"database": "dismod-at-dev"}
-    ec.parameters.update(dict(a=47))
-    assert ec.parameters.a == 47
-    fit_db = ec.fit_db_path()
-    assert fit_db.parent.exists()
+    ec.parameters.base_directory = "."
+    ec.parameters.organizational_mode = "infrastructure"
+    assert ec.parameters.base_directory == "."
+    ec.parameters.modelable_entity_id = meid
+    ec.parameters.model_version_id = mvid
+    db_path = ec.db_path(120)
+    expect_base = (Path(".") / expected).expanduser()
+    assert db_path == expect_base
+
+
+@pytest.mark.parametrize("meid,mvid,expected", [
+    (4321, 267737, "mytmp/120"),
+    (None, 267737, "mytmp/120"),
+])
+def test_execution_context_local_file_interface(tmp_path, meid, mvid, expected):
+    ec = ExecutionContext()
+    ec.parameters = {"database": "dismod-at-dev"}
+    ec.parameters.base_directory = "./mytmp"
+    ec.parameters.organizational_mode = "local"
+    ec.parameters.modelable_entity_id = meid
+    ec.parameters.model_version_id = mvid
+    db_path = ec.db_path(120)
+    expect_base = (Path(".") / expected).expanduser()
+    assert db_path == expect_base

--- a/tests/core/test_execution_context.py
+++ b/tests/core/test_execution_context.py
@@ -1,0 +1,16 @@
+from cascade.core.context import ExecutionContext
+
+
+def test_make_execution_context():
+    ec = ExecutionContext()
+    ec.parameters = {"database": "dismod-at-dev", "bundle_database": "epi"}
+    assert ec.parameters.database == "dismod-at-dev"
+
+
+def test_execution_context_file_interface(tmp_path):
+    ec = ExecutionContext()
+    ec.parameters = {"database": "dismod-at-dev"}
+    ec.parameters.update(dict(a=47))
+    assert ec.parameters.a == 47
+    fit_db = ec.fit_db_path()
+    assert fit_db.parent.exists()

--- a/tests/executor/test_estimate_locations.py
+++ b/tests/executor/test_estimate_locations.py
@@ -16,13 +16,13 @@ from cascade.testing_utilities.fake_data import retrieve_fake_data
 @pytest.mark.parametrize("meid,mvid", [
     (None, 267800),
 ])
-def test_with_known_id(ihme, meid, mvid):
+def test_with_known_id(ihme, meid, mvid, tmp_path):
     """This runs the equivalent of dismodel_main.main"""
     ec = make_execution_context()
     # no-upload keeps this from going to the databases when it's done.
     args = ["z.db", "--no-upload", "--db-only"]
     if mvid:
-        args += ["--mvid", str(mvid)]
+        args += ["--mvid", str(mvid), "--base-directory", str(tmp_path)]
     elif meid:
         args += ["--meid", str(meid)]
     else:


### PR DESCRIPTION
This does one thing: It establishes a directory structure relative to a base directory.

The shell script on the cluster will use the `--infrastructure` flag, which makes nested directories for meid / mvid / location id. Without that, you are running in "local mode" which means there is a separate directory for each location.

This was tested both in unit tests and by running an example mvid from meid=23514 under infrastructure mode.