### PR TITLE
added an ignore to the pytest warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,14 @@ envlist = py36,docs
 xfail_strict = true
 testpaths = tests
 # invalid escape sequence = using latex in non-raw docstrings, by libraries.
-# numpy.ufunc = mismatch between compiled and machine-specific somehow.
+# numpy.ufunc = float size change, noticed by Cython, should ignore.
+# numpy.dtype = float size change, noticed by Cython, should ignore.
 # can't resolve = library using dynamic loading, but it works fine.
 filterwarnings =
     error::Warning
     ignore:invalid escape sequence:DeprecationWarning
     ignore:numpy.ufunc size changed
+    ignore:numpy.dtype size changed
     ignore:can't resolve package from __spec__:ImportWarning
 [testenv]
 extras = testing


### PR DESCRIPTION
A new Cython warning popped up. Apparently, according to the numpy issues site, they are at war with numpy, who don't care about these Cython messages. I thought I'd silence it now instead of waiting for it to stop an install later.