### PR TITLE
these two fixes make this work on the cluster and with the python 3.7.1

### DIFF
--- a/scripts/automation/install.sh
+++ b/scripts/automation/install.sh
@@ -103,7 +103,7 @@ echo $ENV
 
 # Create the virtual environment for the project code and required packages
 
-"${PYTHON_MINICONDA}/bin/python" -m venv "${ENV}"
+"${PYTHON_MINICONDA}/bin/python" -m venv --system-site-packages "${ENV}"
 
 source "${ENV}/bin/activate"
 pip install --upgrade pip

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,13 @@ testpaths = tests
 # invalid escape sequence = using latex in non-raw docstrings, by libraries.
 # numpy.ufunc = mismatch between compiled and machine-specific somehow.
 # can't resolve = library using dynamic loading, but it works fine.
+# sqlalchemy deprecation = an argument from sqlalchemy we can't control
 filterwarnings =
     error::Warning
     ignore:invalid escape sequence:DeprecationWarning
     ignore:numpy.ufunc size changed
     ignore:can't resolve package from __spec__:ImportWarning
+    ignore: The create_engine.convert_unicode
 [testenv]
 extras = testing
 commands = py.test


### PR DESCRIPTION
Two fixes
a) need to inherit packages from conda in order to build on the cluster b/c the cluster can't build things
b) need to silence warning that comes from db_tools using sqlalchemy for new sqlalchemy