### PR TITLE
changed sex_id to sexes because it is no longer a single id but a list

### DIFF
--- a/src/cascade/executor/cascade_plan.py
+++ b/src/cascade/executor/cascade_plan.py
@@ -17,10 +17,10 @@ CODELOG, MATHLOG = getLoggers(__name__)
 
 class EstimationParameters:
     def __init__(self, settings, policies, children,
-                 parent_location_id, grandparent_location_id, sex_id, number_of_fixed_effect_samples):
+                 parent_location_id, grandparent_location_id, sexes, number_of_fixed_effect_samples):
 
         self.parent_location_id = parent_location_id
-        self.sex_id = sex_id
+        self.sexes = sexes
         self.data_access = ParameterProperty()
         """These decide which data to get."""
 
@@ -91,10 +91,10 @@ class CascadePlan:
         parent_location_id = self._location_of_cascade_job(cascade_job_id)
         if self._settings.model.is_field_unset("drill_sex"):
             # An unset drill sex gets all data.
-            sex_id = [1, 2, 3]
+            sexes = [1, 2, 3]
         else:
             # Setting to male or female pulls in "both."
-            sex_id = [self._settings.model.drill_sex, 3]
+            sexes = [self._settings.model.drill_sex, 3]
 
         policies = policies_from_settings(self._settings)
         local_settings = EstimationParameters(
@@ -104,7 +104,7 @@ class CascadePlan:
             parent_location_id=parent_location_id,
             grandparent_location_id=grandparent_location_id,
             # This is a list of [1], [3], [1,3], [2,3], [1,2,3], not [1,2].
-            sex_id=sex_id,
+            sexes=sexes,
             number_of_fixed_effect_samples=policies["number_of_fixed_effect_samples"],
         )
         local_settings.data_access = _ParameterHierarchy(**dict(

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -125,11 +125,11 @@ def retrieve_data(execution_context, local_settings, covariate_data_spec, local_
     include_birth_prevalence = local_settings.settings.model.birth_prev
     data.average_integrand_cases = \
         make_average_integrand_cases_from_gbd(
-            data.ages_df, data.years_df, local_settings.sex_id,
+            data.ages_df, data.years_df, local_settings.sexes,
             local_settings.children, include_birth_prevalence)
     # This comes in yearly from 1950 to 2018
     data.age_specific_death_rate = asdr_as_fit_input(
-        local_settings.parent_location_id, local_settings.sex_id,
+        local_settings.parent_location_id, local_settings.sexes,
         data_access.gbd_round_id, data.ages_df, with_hiv=data_access.with_hiv)
 
     data.cause_specific_mortality_rate = get_raw_csmr(
@@ -166,7 +166,7 @@ def modify_input_data(input_data, local_settings, covariate_data_spec):
     for set_density in ev_settings.data_density_by_integrand:
         density[id_to_integrand[set_density.integrand_measure_id]] = set_density.value
 
-    csmr = normalize_csmr(input_data.cause_specific_mortality_rate, local_settings.sex_id)
+    csmr = normalize_csmr(input_data.cause_specific_mortality_rate, local_settings.sexes)
     CODELOG.debug(f"bundle cols {input_data.bundle.columns}\ncsmr cols {csmr.columns}")
     assert not set(csmr.columns) - set(input_data.bundle.columns)
     bundle_with_added = pd.concat([input_data.bundle, csmr], sort=False)
@@ -209,7 +209,7 @@ def set_sex_reference(covariate_data_spec, local_settings):
             (2, 3): [-0.5, 0.75],
             (1, 2, 3): [0.0, 0.75],
         }
-        reference, max_difference = sex_assignments_to_exclude_by_value[tuple(sorted(local_settings.sex_id))]
+        reference, max_difference = sex_assignments_to_exclude_by_value[tuple(sorted(local_settings.sexes))]
         sex_covariate[0].reference = reference
         sex_covariate[0].max_difference = max_difference
 

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -53,14 +53,14 @@ def get_asdr_data(gbd_round_id, location_and_children, with_hiv):
     return asdr[cols]
 
 
-def asdr_as_fit_input(location_ids, sex_id, gbd_round_id, ages_df, with_hiv):
+def asdr_as_fit_input(location_ids, sexes, gbd_round_id, ages_df, with_hiv):
     r"""Gets age-specific death rate (ASDR) from database and formats as
     input data. This is :math:`{}_nm_x`, the mortality rate by age group.
     Returns rates, not counts.
 
     Args:
         location_ids (List[int]|int): Location for which to get data.
-        sex_id (int): 1, 2, 3, or 4. Sex_id.
+        sexes (int): 1, 2, 3, or 4. Sex_id.
         gbd_round_id (int): GBD round identifies consistent data sets.
         ages_df (pd.DataFrame): Age_id to age mapping.
         with_hiv (bool): whether to include HIV deaths in mortality.
@@ -77,10 +77,10 @@ def asdr_as_fit_input(location_ids, sex_id, gbd_round_id, ages_df, with_hiv):
 
     asdr = get_asdr_data(gbd_round_id, location_ids, with_hiv)
     assert not (set(asdr.age_group_id.unique()) - set(ages_df.age_group_id.values))
-    return asdr_by_sex(asdr, ages_df, sex_id)
+    return asdr_by_sex(asdr, ages_df, sexes)
 
 
-def asdr_by_sex(asdr, ages, sex_id):
+def asdr_by_sex(asdr, ages, sexes):
     """Incoming age-specific death rate has ``age_id`` and upper and lower
     bounds. This translates those into age-ranges, time-ranges, and standard
     deviations."""
@@ -99,7 +99,7 @@ def asdr_by_sex(asdr, ages, sex_id):
         nu=nan,
     )
     trimmed = rest.drop(columns=["age_group_id", "upper", "lower"])
-    return trimmed.query("sex_id in @sex_id").drop(columns=["sex_id"])
+    return trimmed.query("sex_id in @sexes").drop(columns=["sex_id"])
 
 
 def _upload_asdr_data_to_tier_3(gbd_round_id, cursor, model_version_id, asdr_data):

--- a/src/cascade/testing_utilities/fake_data.py
+++ b/src/cascade/testing_utilities/fake_data.py
@@ -102,14 +102,14 @@ def retrieve_fake_data(execution_context, local_settings, covariate_data_spec, r
     include_birth_prevalence = local_settings.settings.model.birth_prev
     data.average_integrand_cases = \
         make_average_integrand_cases_from_gbd(
-            data.ages_df, data.years_df, local_settings.sex_id,
+            data.ages_df, data.years_df, local_settings.sexes,
             local_settings.children, include_birth_prevalence)
 
     all_ages = age_spans.get_age_spans()
     data.cause_specific_mortality_rate = get_raw_csmr(
         execution_context, local_settings.data_access, local_settings.parent_location_id, all_ages)
     data.age_specific_death_rate = asdr_as_fit_input(
-        local_settings.parent_location_id, local_settings.sex_id,
+        local_settings.parent_location_id, local_settings.sexes,
         data_access.gbd_round_id, data.ages_df, with_hiv=data_access.with_hiv)
     data.study_id_to_name, data.country_id_to_name = find_covariate_names(
         execution_context, covariate_data_spec)


### PR DESCRIPTION
Rename of a variable that had become confusing because it went from an integer to a list.
This should reduce confusion and clarify where we decide that when a user chooses "female" that the data that they get is from sex=female and sex=both.