### PR TITLE
Feature/detailed priors on grids

### DIFF
--- a/docs/epiviz/model_building.rst
+++ b/docs/epiviz/model_building.rst
@@ -8,6 +8,7 @@ Model Building
    :maxdepth: 2
 
    session_options
+   smooth_grid_priors
    omega_constraint
    prior_eta
    posteriors_to_priors

--- a/docs/epiviz/smooth_grid_priors.rst
+++ b/docs/epiviz/smooth_grid_priors.rst
@@ -1,0 +1,36 @@
+.. _smooth-grid-priors:
+
+
+Smooth Grid Priors
+==================
+
+For the Rate tab, Random Effect tab, Study tab and Country Covariate tab,
+the interface sets priors. This describes how those settings are interpreted.
+Most of this work happens in the function
+:py:func:`cascade.executor.construct_model.smooth_grid_from_smoothing_form`,
+and you can check its source there.
+
+The default value, dage, and dtime priors are used to initialize those parts
+of the smooth grid. For smooth grids with only one age, the dage priors
+aren't meaningful, and the same is true for dtime priors when there is
+only one year.
+
+After that, the detailed priors are applied in the order they appear in
+the settings, and note that the order may or may not reflect the order
+in the user interface. There are three ways to specify which age
+and time points each detailed prior applies to:
+
+ *  ``age_lower`` and ``age_upper`` - A missing value here (one that's not
+    filled-in in the UI) is treated as -infinity or infinity, respectively.
+
+ *  ``time_lower`` and ``time_upper`` - Missing values similarly set to
+    include all points on that side.
+
+ *  ``born_lower`` and ``born_upper`` - Each line for the born limit
+    corresponds to :math:`a \le t - b` or :math:`a \ge t - b`, respectively.
+
+For each prior, all three of these sieves are applied to the grid of
+ages and times defined by the age values and time values for that smooth grid.
+If a detailed prior doesn't match any of the age and time points in this grid,
+there will be a statement in the log that says "No ages and times match prior
+with extents <lower and upper extents>."

--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -190,14 +190,16 @@ def matching_knots(rate_grid, smoothing_prior):
     extents = dict()
     for extent in ["age", "time", "born"]:
         extents[extent] = np.zeros(2, dtype=np.float)
-        for sidx, side, default_extent in [(0, "lower", -inf), (1, "upper", inf)]:
+        for side_idx, side, default_extent in [(0, "lower", -inf), (1, "upper", inf)]:
             name = f"{extent}_{side}"
             if smoothing_prior.is_field_unset(name):
-                extents[extent][sidx] = default_extent
+                extents[extent][side_idx] = default_extent
             else:
-                extents[extent][sidx] = getattr(smoothing_prior, name)
+                extents[extent][side_idx] = getattr(smoothing_prior, name)
+    # meshgrid generates every combination of age and time as two numpy arrays.
     ages, times = np.meshgrid(rate_grid.ages, rate_grid.times)
-    # result is shape (len(times), len(ages)), backwards
+    assert ages.shape == (len(rate_grid.times), len(rate_grid.ages))
+    assert times.shape == (len(rate_grid.times), len(rate_grid.ages))
     in_age = (ages >= extents["age"][0]) & (ages <= extents["age"][1])
     in_time = (times >= extents["time"][0]) & (times <= extents["time"][1])
     in_born = (ages <= times - extents["born"][0]) & (ages >= times - extents["born"][1])

--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 import numpy as np
+from numpy import inf
 
 from cascade.core.log import getLoggers
 from cascade.model import (
@@ -147,6 +148,15 @@ def constraint_from_rectangular_data(rate_var, default_age_time):
 
 
 def smooth_grid_from_smoothing_form(default_age_time, single_age_time, smooth):
+    """
+
+    Args:
+        default_age_time (List[ages, times]): Two members, the ages and the time.
+        single_age_time (List[float]): Two members, an age and a time.
+        smooth (cascade.input_data.configuration.form.Smoothing): The form element.
+    Returns:
+        SmoothGrid: A new smooth grid.
+    """
     ages, times = construct_grid_ages_times(default_age_time, single_age_time, smooth)
     rate_grid = SmoothGrid(ages=ages, times=times)
     for kind in ["value", "dage", "dtime"]:
@@ -154,7 +164,56 @@ def smooth_grid_from_smoothing_form(default_age_time, single_age_time, smooth):
             getattr(rate_grid, kind)[:, :] = getattr(smooth.default, kind).prior_object
         else:
             pass  # An unset prior should be unused (dage for one age, dtime for one time)
+    if smooth.is_field_unset("detail"):
+        return
+
+    for smoothing_prior in smooth.detail:
+        for a, t in matching_knots(rate_grid, smoothing_prior):
+            getattr(rate_grid, smoothing_prior.prior_type)[
+                a, t] = smoothing_prior.prior_object
     return rate_grid
+
+
+def matching_knots(rate_grid, smoothing_prior):
+    """
+    Get lower and upper out of the smoothing prior
+
+    Args:
+        smoothing_prior (cascade.input_data.configuration.form.SmoothingPrior):
+            A single smoothing prior.
+
+    Returns:
+        Iterator over (a, t) that match. Can be nothing.
+    """
+    extents = dict()
+    for extent in ["age", "time", "born"]:
+        extents[extent] = np.zeros(2, dtype=np.float)
+        for sidx, side, default_extent in [(0, "lower", -inf), (1, "upper", inf)]:
+            name = f"{extent}_{side}"
+            if smoothing_prior.is_field_unset(name):
+                extents[extent][sidx] = default_extent
+            else:
+                extents[extent][sidx] = getattr(smoothing_prior, name)
+    ages, times = np.meshgrid(rate_grid.ages, rate_grid.times)
+    # result is shape (len(times), len(ages)), backwards
+    in_age = (ages >= extents["age"][0]) & (ages <= extents["age"][1])
+    in_time = (times >= extents["time"][0]) & (times <= extents["time"][1])
+    in_born = (ages <= times - extents["born"][0]) & (ages >= times - extents["born"][1])
+    cover = in_age & in_time & in_born
+    if not np.any(cover):
+        MATHLOG.info(f"No ages and times match prior with extents {extents}.")
+    yield from zip(ages[cover], times[cover])
+
+
+def add_detailed_priors_to_grid(rate_grid, smooth):
+    """
+    Translated the "detailed" section of the EpiViz-AT Form.
+
+    Args:
+        rate_grid (SmoothGrid): The Smooth Grid to modify in place.
+        smooth (cascade.input_data.configuration.form.Smoothing): The form element.
+    """
+
 
 
 def construct_grid_ages_times(default_age_time, single_age_time, smooth):

--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -164,13 +164,10 @@ def smooth_grid_from_smoothing_form(default_age_time, single_age_time, smooth):
             getattr(rate_grid, kind)[:, :] = getattr(smooth.default, kind).prior_object
         else:
             pass  # An unset prior should be unused (dage for one age, dtime for one time)
-    if smooth.is_field_unset("detail"):
-        return
-
-    for smoothing_prior in smooth.detail:
-        for a, t in matching_knots(rate_grid, smoothing_prior):
-            getattr(rate_grid, smoothing_prior.prior_type)[
-                a, t] = smoothing_prior.prior_object
+    if not smooth.is_field_unset("detail"):
+        for smoothing_prior in smooth.detail:
+            for a, t in matching_knots(rate_grid, smoothing_prior):
+                getattr(rate_grid, smoothing_prior.prior_type)[a, t] = smoothing_prior.prior_object
     return rate_grid
 
 
@@ -203,17 +200,6 @@ def matching_knots(rate_grid, smoothing_prior):
     if not np.any(cover):
         MATHLOG.info(f"No ages and times match prior with extents {extents}.")
     yield from zip(ages[cover], times[cover])
-
-
-def add_detailed_priors_to_grid(rate_grid, smooth):
-    """
-    Translated the "detailed" section of the EpiViz-AT Form.
-
-    Args:
-        rate_grid (SmoothGrid): The Smooth Grid to modify in place.
-        smooth (cascade.input_data.configuration.form.Smoothing): The form element.
-    """
-
 
 
 def construct_grid_ages_times(default_age_time, single_age_time, smooth):

--- a/src/cascade/executor/create_settings.py
+++ b/src/cascade/executor/create_settings.py
@@ -331,7 +331,7 @@ class SettingsChoices:
 def make_locations(depth):
     """Creates locations of given depth as a balanced tree. Root is 1."""
     arity = 3
-    zero_based = nx.balanced_tree(arity, depth, nx.DiGraph)
+    zero_based = nx.balanced_tree(arity, depth, nx.DiGraph())
     locations = nx.relabel_nodes(zero_based, {i: i + 1 for i in range(len(zero_based))})
     for lidx, n in enumerate(locations.nodes):
         locations.nodes[n]["location_name"] = str(lidx)

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -40,6 +40,8 @@ class SmoothingPrior(Form):
     age_upper = FloatField(nullable=True, display="Age upper")
     time_lower = FloatField(nullable=True, display="Time lower")
     time_upper = FloatField(nullable=True, display="Time upper")
+    born_lower = FloatField(nullable=True, display="Born lower")
+    born_upper = FloatField(nullable=True, display="Born upper")
     density = OptionField(
         ["uniform", "gaussian", "laplace", "students", "log_gaussian", "log_laplace", "log_students"], display="Density"
     )

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -113,7 +113,7 @@ class SmoothingPrior(Form):
 class SmoothingPriorGroup(Form):
     dage = SmoothingPrior(name_field="prior_type", nullable=True, display="Age diff")
     dtime = SmoothingPrior(name_field="prior_type", nullable=True, display="Time diff")
-    value = SmoothingPrior(name_field="prior_type", display="Values")
+    value = SmoothingPrior(name_field="prior_type", nullable=True, display="Values")
 
 
 class Smoothing(Form):

--- a/tests/executor/test_construct_model.py
+++ b/tests/executor/test_construct_model.py
@@ -249,4 +249,3 @@ def test_matching_knots(kind, al, au, tl, tu, bl, bu, cnt):
     assert len(age_time) == cnt
     # uniqueness
     assert len({(a, t) for (a, t) in age_time}) == len(age_time)
-    

--- a/tests/executor/test_construct_model.py
+++ b/tests/executor/test_construct_model.py
@@ -1,11 +1,14 @@
 import pickle
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from numpy import isclose
+import numpy as np
+from numpy import isclose, inf
 from numpy.random import RandomState
 
 from cascade.executor.cascade_plan import CascadePlan
+from cascade.executor.construct_model import matching_knots
 from cascade.executor.covariate_description import create_covariate_specifications
 from cascade.executor.create_settings import (
     create_local_settings, create_settings, SettingsChoices
@@ -15,6 +18,7 @@ from cascade.executor.estimate_location import (
     modify_input_data, construct_model
 )
 from cascade.executor.session_options import make_options
+from cascade.input_data.configuration.form import SmoothingPrior
 from cascade.input_data.db.locations import location_hierarchy, location_hierarchy_to_dataframe
 from cascade.model.session import Session
 from cascade.testing_utilities import make_execution_context
@@ -212,3 +216,37 @@ def test_option_settings(ihme, tmp_path, base_settings, reference_db, setstr, va
     assert compare.different_tables() & {"option"}
     print(compare.record_differences("option"))
     assert compare.diff_contains("option", opt)
+
+
+@pytest.mark.parametrize("kind,al,au,tl,tu,bl,bu,cnt",[
+    ("data", 0, 10, 2000, 2040, 1000, inf, 11 * 4),
+    ("data", 0, 30, 2000, 2040, 1000, inf, 20 * 4),
+    ("data", 0, 10, 1980, 2040, 1000, inf, 11 * 5),
+    ("data", 0, 10, 2000, 2040, -inf, inf, 11 * 4),
+    ("data", 0, 10, 2000, 2040, 1991, inf, 11 * 4 - 1),
+    ("data", 0, 10, 2000, 2040, 1000, 2014, 11 * 4 - 1),
+    ("data", 0, 10, 2000, 2040, 1991, 2014, 11 * 4 - 2),
+])
+def test_matching_knots(kind, al, au, tl, tu, bl, bu, cnt):
+    """See if subselection of ages and times by detailed priors works."""
+    prior = SmoothingPrior()
+    prior_set = dict(
+        prior_type=kind,
+        age_lower=al,
+        age_upper=au,
+        time_lower=tl,
+        time_upper=tu,
+        born_lower=bl,
+        born_upper=bu
+    )
+    for elem, value in prior_set.items():
+        setattr(prior, elem, value)
+    prior.validate_and_normalize()
+    grid = SimpleNamespace()
+    grid.ages = np.arange(20)
+    grid.times = np.array([1990, 2000, 2005, 2010, 2015])
+    age_time = list(matching_knots(grid, prior))
+    assert len(age_time) == cnt
+    # uniqueness
+    assert len({(a, t) for (a, t) in age_time}) == len(age_time)
+    


### PR DESCRIPTION
This enables a modeler to

* select mulstd priors on the Rate, Random Effect, Study Covariate, and Country Covariate tabs
* create detailed priors on the Rate, Random Effect, Study Covariate, and Country Covariate tabs

The second feature is more likely to be useful.