### PR TITLE
sets minimum measured coefficient of variation from settings

### DIFF
--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -14,7 +14,7 @@ from cascade.executor.construct_model import construct_model
 from cascade.executor.covariate_data import find_covariate_names, add_covariate_data_to_observations_and_avgints
 from cascade.executor.covariate_description import create_covariate_specifications
 from cascade.executor.priors_from_draws import set_priors_from_parent_draws
-from cascade.executor.session_options import make_options
+from cascade.executor.session_options import make_options, make_minimum_meas_cv
 from cascade.input_data.configuration.construct_bundle import (
     normalized_bundle_from_database,
     normalized_bundle_from_disk,
@@ -285,6 +285,7 @@ def _fit_and_predict_fixed_effect_sample(sim_model, sim_data, fit_file, location
     )
     local_settings.settings.policies.meas_std_effect
     sim_session.set_option(**make_options(local_settings.settings))
+    sim_session.set_minimum_meas_cv(**make_minimum_meas_cv(local_settings.settings))
     begin = timer()
     sim_fit_result = sim_session.fit(sim_model, sim_data)
     CODELOG.info(f"fit {timer() - begin} success {sim_fit_result.success}")
@@ -344,6 +345,7 @@ def make_draws(execution_context, model, input_data, max_fit, local_settings, nu
         filename=base_path / "simulate.db"
     )
     session.set_option(**make_options(local_settings.settings))
+    session.set_minimum_meas_cv(**make_minimum_meas_cv(local_settings.settings))
     simulate_result = session.simulate(model, input_data.observations, max_fit, draw_cnt)
 
     loop = asyncio.get_event_loop()

--- a/src/cascade/executor/session_options.py
+++ b/src/cascade/executor/session_options.py
@@ -1,3 +1,5 @@
+from cascade.dismod.constants import IntegrandEnum
+
 
 def make_options(ev_settings):
     """This sets Dismod-AT options from the EpiViz-AT settings and model.
@@ -46,3 +48,10 @@ def make_options(ev_settings):
         options["bound_random"] = ev_settings.model.bound_random
 
     return options
+
+
+def make_minimum_meas_cv(ev_settings):
+    if not ev_settings.model.is_field_unset("minimum_meas_cv"):
+        return {integrand.name: ev_settings.model.minimum_meas_cv for integrand in IntegrandEnum}
+    else:
+        return {}

--- a/src/cascade/model/object_wrapper.py
+++ b/src/cascade/model/object_wrapper.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from cascade.core import getLoggers
-from cascade.dismod.constants import DensityEnum, RateEnum
+from cascade.dismod.constants import DensityEnum, RateEnum, IntegrandEnum
 from cascade.dismod.db.wrapper import DismodFile, get_engine
 from cascade.model.serialize import default_integrand_names, make_log_table
 from cascade.model.data_read_write import (
@@ -141,6 +141,16 @@ class ObjectWrapper:
         var_id = read_var_table_as_id(self.dismod_file)
         write_vars(self.dismod_file, new_vars, var_id, name)
         self.flush()
+
+    def set_minimum_meas_cv(self, integrand, value):
+        if value is not None:
+            fvalue = float(value)
+            assert fvalue >= 0.0
+        else:
+            fvalue = 0
+        integrand = IntegrandEnum[integrand]
+        dmf = self.dismod_file
+        dmf.integrand.loc[dmf.integrand.integrand_name == integrand.name, "minimum_meas_cv"] = fvalue
 
     @property
     def prior_residuals(self):

--- a/src/cascade/model/session.py
+++ b/src/cascade/model/session.py
@@ -229,6 +229,19 @@ class Session:
         if self._objects.dismod_file:
             self._objects.set_option(**self._options)
 
+    def set_minimum_meas_cv(self, **kwargs):
+        """Sets the minimum coefficient of variation for this integrand.
+        The name is one of :py:class:`cascade.dismod.constants.IntegrandEnum`.
+        integrand_name (str) The canonical Dismod-AT name for the integrand.
+        value (float) A value greater-than or equal to zero. If it is
+        zero, then there is no coefficient of variation for this integrand.
+
+        Args:
+            name-value pairs: This is a set of integrand=value pars.
+        """
+        for integrand_name, value in kwargs.items():
+            self._objects.set_minimum_meas_cv(integrand_name, value)
+
     def _run_dismod(self, command):
         """Pushes tables to the db file, runs Dismod-AT, and refreshes
         tables written."""


### PR DESCRIPTION
This enables a feature on the advanced tab to set "minimum Data CV". It is the coefficient of variation on the data. That means we treat data as having at least a minimum amount of uncertainty, no matter what is input from the bundle.