### PR TITLE
Remove reference to generate_draws

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ git:
 language: python
 python:
     - "3.6"
+before_install:
+    - sudo apt-get install -y libhdf5-dev
 install:
     - pip install tox flake8
 script:

--- a/docs/refmanual/saver.rst
+++ b/docs/refmanual/saver.rst
@@ -3,5 +3,5 @@
 Saver Functionality
 ====================
 
-.. automodule:: cascade.saver.generate_draws
+.. automodule:: cascade.saver.save_prediction
     :members:


### PR DESCRIPTION
I didn't look at the error message from travis closely enough. The problem wasn't with namespace packages it was with this stray reference to generate_draws