### PR TITLE
got rid of min meas error

### DIFF
--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -269,7 +269,6 @@ def _fit_and_predict_fixed_effect_sample(sim_model, sim_data, fit_file, location
         parent_location=parent_location,
         filename=fit_file
     )
-    local_settings.settings.policies.meas_std_effect
     sim_session.set_option(**make_options(local_settings.settings, local_settings.model_options))
     sim_session.set_minimum_meas_cv(**make_minimum_meas_cv(local_settings.settings))
     begin = timer()
@@ -323,6 +322,7 @@ async def _async_make_draws(base_path, input_data, model, local_settings, simula
 
 def make_draws(execution_context, model, input_data, max_fit, local_settings, num_processes):
     base_path = execution_context.db_path(local_settings.parent_location_id)
+    MATHLOG.info(f"DB files for {local_settings.parent_location_id} in {base_path}.")
     base_path.mkdir(parents=True, exist_ok=True)
     draw_cnt = local_settings.number_of_fixed_effect_samples
     session = Session(

--- a/src/cascade/model/object_wrapper.py
+++ b/src/cascade/model/object_wrapper.py
@@ -150,7 +150,10 @@ class ObjectWrapper:
             fvalue = 0
         integrand = IntegrandEnum[integrand]
         dmf = self.dismod_file
-        dmf.integrand.loc[dmf.integrand.integrand_name == integrand.name, "minimum_meas_cv"] = fvalue
+        if dmf:
+            dmf.integrand.loc[dmf.integrand.integrand_name == integrand.name, "minimum_meas_cv"] = fvalue
+        else:
+            CODELOG.info(f"minimum_meas_cv not set because dismod_file is None.")
 
     @property
     def prior_residuals(self):

--- a/src/cascade/model/session.py
+++ b/src/cascade/model/session.py
@@ -260,12 +260,15 @@ class Session:
 
     def _check_dismod_command(self, command, stdout, stderr):
         log = self._objects.log
+        oom_sentinel = "std:bad_alloc"
+        max_iter_sentinel = "Maximum Number of Iterations Exceeded"
         if len(log) == 0 or f"end {command}" not in log.message.iloc[-1]:
-            if "std:bad_alloc" in stdout or "std::bad_alloc" in stderr:
-                message = "Dismod-AT ran out of memory"
+            if oom_sentinel in stdout or oom_sentinel in stderr:
+                raise DismodATException("Dismod-AT ran out of memory")
+            elif max_iter_sentinel in stdout or max_iter_sentinel in stderr:
+                MATHLOG.warning("Dismod-AT exceeded iterations")
             else:
-                message = f"Dismod-AT failed to complete '{command}' command"
-            raise DismodATException(message)
+                raise DismodATException(f"Dismod-AT failed to complete '{command}' command")
 
     @staticmethod
     def _check_vars(var):


### PR DESCRIPTION
Bugfix.

1. After running a location, there was a crash when setting minimum_measured_cv on the data, when generating simulations. The cause is that the database file isn't initialized. This quiets the problem but doesn't set minimum_measured_cv.
2. max iterations was a failure and is now not a failure. It lets you keep computing even if the solution doesn't converge within the given tolerance.
3. prints location of db file again.