### PR TITLE
Bugfix/parameters uses different format

### DIFF
--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -241,8 +241,6 @@ def compute_location(execution_context, local_settings, input_data, model):
         session.setup_model_for_fit(model, input_data.observations)
         return None, None
     CODELOG.info(f"fit {timer() - begin}")
-    if not fit_result.success:
-        raise DismodATException("Fit failed")
 
     draws = make_draws(
         execution_context,
@@ -274,18 +272,15 @@ def _fit_and_predict_fixed_effect_sample(sim_model, sim_data, fit_file, location
     begin = timer()
     sim_fit_result = sim_session.fit(sim_model, sim_data)
     CODELOG.info(f"fit {timer() - begin} success {sim_fit_result.success}")
-    if sim_fit_result.success:
-        CODELOG.debug(f"sim fit {draw_idx} success")
-        predicted, _ = sim_session.predict(
-            sim_fit_result.fit,
-            average_integrand_cases.drop("sex_id", "columns"),
-            parent_location,
-            covariates=covariates
-        )
-        return (sim_fit_result.fit, predicted)
-    else:
-        CODELOG.debug(f"sim fit {draw_idx} not successful in {fit_file}.")
-        return None
+
+    CODELOG.debug(f"sim fit {draw_idx} success")
+    predicted, _ = sim_session.predict(
+        sim_fit_result.fit,
+        average_integrand_cases.drop("sex_id", "columns"),
+        parent_location,
+        covariates=covariates
+    )
+    return (sim_fit_result.fit, predicted)
     # XXX make the Session close or be a contextmanager.
 
 

--- a/src/cascade/input_data/configuration/construct_country.py
+++ b/src/cascade/input_data/configuration/construct_country.py
@@ -276,8 +276,8 @@ def check_binary_covariates(execution_context, covariate_ids):
     is_binary = dict()
     for covariate_id in covariate_ids:
         result_df = ezfuncs.query(
-            "select dichotomous from shared.covariate where covariate_id=?",
-            parameters=(covariate_id,),
+            "select dichotomous from shared.covariate where covariate_id=:covid",
+            parameters=dict(covid=covariate_id),
             conn_def=execution_context.parameters.database)
         is_binary[covariate_id] = (result_df.dichotomous[0] == 1)
     return is_binary
@@ -288,8 +288,8 @@ def check_and_handle_binary_covariate(covariate_id, covariate_column, execution_
     If it is, make sure the assigned value is only 0 or 1.
     """
     result_df = ezfuncs.query(
-        "select dichotomous from shared.covariate where covariate_id=?",
-        parameters=(covariate_id,),
+        "select dichotomous from shared.covariate where covariate_id=:covid",
+        parameters=dict(covid=covariate_id),
         conn_def=execution_context.parameters.database)
 
     if result_df.dichotomous[0] == 1:


### PR DESCRIPTION
Two things:
1. Benefit 1 is not crashing. The new version of ezfuncs accepts parameters using a _different format_, and it didn't say that, and I didn't guess.
2. Benefit 2 is allowing Dismod-AT fits that go to "max iterations" to be treated as OK. This PR removes code that checks for a successful fit. It assumes, instead, that any fit that ends with an out-of-memory or other error will throw an exception.