### PR TITLE
covariate raw_input specification is more correct

### DIFF
--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -261,7 +261,7 @@ def construct_model_random_effects(default_age_time, single_age_time, ev_setting
 
 
 def construct_model_covariates(default_age_time, single_age_time, covariate_multipliers, model):
-    """The covariat multipliers are of all types: alpha, beta, and gamma. This adds
+    """The covariate multipliers are of all types: alpha, beta, and gamma. This adds
     their priors to the Model.
 
     Args:

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -99,10 +99,11 @@ def retrieve_data(execution_context, local_settings, covariate_data_spec, local_
 
     country_covariate_ids = {spec.covariate_id for spec in covariate_data_spec if spec.study_country == "country"}
     # Raw country covariate data.
+    parent_and_children = local_settings.children + [local_settings.parent_location_id]
     covariates_by_age_id = country_covariate_set(
         country_covariate_ids,
         demographics=dict(age_group_ids="all", year_ids="all", sex_ids="all",
-                          location_ids=local_settings.parent_location_id),
+                          location_ids=parent_and_children),
         gbd_round_id=data_access.gbd_round_id,
     )
     # Every age group defined, so that we can search for what's given.

--- a/src/cascade/input_data/configuration/raw_input.py
+++ b/src/cascade/input_data/configuration/raw_input.py
@@ -74,6 +74,7 @@ EXPECTED_TYPES = dict(
         ('time_upper', dtype('float64')),
         ('sex_id', dtype('int64')),
         ('mean_value', dtype('float64')),
+        ('location_id', dtype('int64')),
     ]
 )
 """These are the data frames and column data types that define

--- a/src/cascade/input_data/db/country_covariates.py
+++ b/src/cascade/input_data/db/country_covariates.py
@@ -47,7 +47,7 @@ def country_covariates(covariate_id, demographics, gbd_round_id):
         sex_id=demographics["sex_ids"],
         gbd_round_id=gbd_round_id
     )[[
-        "covariate_id", "covariate_name_short", "location_id", "age_group_id",
+        "location_id", "age_group_id",
         "year_id", "sex_id", "mean_value"
     ]]
 

--- a/tests/input_data/db/test_country_covariates.py
+++ b/tests/input_data/db/test_country_covariates.py
@@ -12,18 +12,18 @@ def mock_db_queries(mocker):
 @pytest.fixture
 def mock_ccov_estimates():
     mock_ccov_estimates = pd.DataFrame(columns=[
-        "covariate_id", "covariate_name_short", "location_id", "age_group_id", "year_id",
+        "location_id", "age_group_id", "year_id",
         "sex_id", "mean_value"])
-    mock_ccov_estimates.loc[0] = [33, "phlegm", 101, 22, 1990, 1, 1000]
+    mock_ccov_estimates.loc[0] = [101, 22, 1990, 1, 1000]
     return mock_ccov_estimates
 
 
 @pytest.fixture
 def expected_ccov():
     expected_ccov = pd.DataFrame(columns=[
-        "covariate_id", "covariate_name_short", "location_id", "age_group_id", "year_id",
+        "location_id", "age_group_id", "year_id",
         "sex_id", "mean_value"])
-    expected_ccov.loc[0] = [33, "phlegm", 101, 22, 1990, 1, 1000]
+    expected_ccov.loc[0] = [101, 22, 1990, 1, 1000]
 
     return expected_ccov
 
@@ -59,10 +59,9 @@ def test_country_covariates_real(ihme, demographics_default):
     ccov = country_covariates(country_covariate_id, demographics_default, gbd_round_id)
 
     assert set(ccov.columns) == {
-        "covariate_id", "covariate_name_short", "location_id", "age_group_id", "year_id", "sex_id", "mean_value"}
+        "location_id", "age_group_id", "year_id", "sex_id", "mean_value"}
 
     assert len(ccov) == 1 * 1 * 2 * 23 * 38
-    assert set(ccov["covariate_id"].unique()) == {26}
     assert set(ccov["location_id"].unique()) == {102}
     assert set(ccov["sex_id"].unique()) == {1, 2}
     # These age groups are fewer than requested. 27 is missing.


### PR DESCRIPTION
the covariates were crashing. this uncrashes them by ensuring the correct columns are specified, but it doesn't fix them. The remaining problem is that the covariate interpolation code for countries assumes one location, and we now have many.