### PR TITLE
moving to 37 if tools allow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
   depth: 3
 language: python
 python:
-    - "3.6"
+    - "3.7"
 before_install:
     - sudo apt-get install -y libhdf5-dev
 install:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,5 @@
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.7
   setup_py_install: false

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Statistics",
     ],
 )


### PR DESCRIPTION
We have been using python 3.7 but haven't changed requirements to reflect this. We have a real dependency on python 3.7 because we use the "async" keyword when starting subprocesses.