### PR TITLE
modified functions to take a decomp_step so that they work with the l…

### DIFF
--- a/examples/graduate_mortality.py
+++ b/examples/graduate_mortality.py
@@ -278,11 +278,12 @@ logging.root.setLevel(logging.INFO)
 location_id = 101  # Canadia
 sex_id = 1
 gbd_round_id = 5
+decomp_step = "step1"
 age_group_set_id = 12
 
 ages_df = db_queries.get_age_metadata(age_group_set_id=age_group_set_id, gbd_round_id=gbd_round_id)
 # This comes in yearly from 1950 to 2018
-mtother = asdr_as_fit_input(location_id, sex_id, gbd_round_id, ages_df, with_hiv=True)
+mtother = asdr_as_fit_input(location_id, sex_id, gbd_round_id, decomp_step, ages_df, with_hiv=True)
 # Reduce years by factor because it's slow with too much data.
 # Maybe smarter to work with a dense set of years, so limit to 1990-2000?
 mtother = mtother[(mtother.time_lower % 10) < 0.1]

--- a/src/cascade/executor/cascade_plan.py
+++ b/src/cascade/executor/cascade_plan.py
@@ -170,7 +170,8 @@ class CascadePlan:
             model_options=model_options,
         )
         local_settings.data_access = _ParameterHierarchy(**dict(
-            gbd_round_id=self._settings.gbd_round_id,
+            gbd_round_id=policies["gbd_round_id"],
+            decomp_step=policies["decomp_step"],
             modelable_entity_id=self._settings.model.modelable_entity_id,
             model_version_id=self._settings.model.model_version_id,
             settings_file=self._args.settings_file,

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -148,6 +148,7 @@ def retrieve_data(execution_context, local_settings, covariate_data_spec, local_
         demographics=dict(age_group_ids="all", year_ids="all", sex_ids="all",
                           location_ids=parent_and_children),
         gbd_round_id=data_access.gbd_round_id,
+        decomp_step=data_access.decomp_step,
     )
     # Every age group defined, so that we can search for what's given.
     all_age_spans = age_spans.get_age_spans()
@@ -174,7 +175,7 @@ def retrieve_data(execution_context, local_settings, covariate_data_spec, local_
     # This comes in yearly from 1950 to 2018
     data.age_specific_death_rate = asdr_as_fit_input(
         parent_and_children, local_settings.sexes,
-        data_access.gbd_round_id, data.ages_df, with_hiv=data_access.with_hiv)
+        data_access.gbd_round_id, data_access.decomp_step, data.ages_df, with_hiv=data_access.with_hiv)
 
     data.cause_specific_mortality_rate = get_raw_csmr(
         execution_context, local_settings.data_access, local_settings.parent_location_id, all_age_spans)

--- a/src/cascade/input_data/configuration/construct_mortality.py
+++ b/src/cascade/input_data/configuration/construct_mortality.py
@@ -27,7 +27,8 @@ def get_raw_csmr(execution_context, data_access, parent_id, age_spans):
             location_and_children,
             data_access.add_csmr_cause,
             data_access.cod_version,
-            data_access.gbd_round_id
+            data_access.gbd_round_id,
+            data_access.decomp_step,
         )
     return convert_gbd_ids_to_dismod_values(raw_csmr, age_spans)
 

--- a/src/cascade/input_data/configuration/form.py
+++ b/src/cascade/input_data/configuration/form.py
@@ -320,6 +320,8 @@ class Policies(Form):
         display="number of most recent iterations taken into account for quasi-Newton"
     )
     fit_strategy = OptionField(["fit", "fit_fixed_then_fit"], default="fit", constructor=int, nullable=True)
+    decomp_step = StrField(nullable=True, default="step1")
+    gbd_round_id = IntField(nullable=True, default=6)
 
 
 class Configuration(Form):

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -26,7 +26,7 @@ def _asdr_in_t3(execution_context, model_version_id):
     return [row[0] for row in location_rows]
 
 
-def get_asdr_data(gbd_round_id, location_and_children, with_hiv):
+def get_asdr_data(gbd_round_id, decomp_step, location_and_children, with_hiv):
     r"""Gets the age-specific death rate from IHME databases.
     This is :math:`{}_nm_x`, the mortality rate. This gets rates, not counts.
     """
@@ -38,6 +38,7 @@ def get_asdr_data(gbd_round_id, location_and_children, with_hiv):
         location_id=location_and_children,
         year_id=-1,
         gbd_round_id=gbd_round_id,
+        decomp_step=decomp_step,
         age_group_id=age_group_ids,
         sex_id=sex_ids,
         with_hiv=with_hiv,
@@ -53,7 +54,7 @@ def get_asdr_data(gbd_round_id, location_and_children, with_hiv):
     return asdr[cols]
 
 
-def asdr_as_fit_input(location_ids, sexes, gbd_round_id, ages_df, with_hiv):
+def asdr_as_fit_input(location_ids, sexes, gbd_round_id, decomp_step, ages_df, with_hiv):
     r"""Gets age-specific death rate (ASDR) from database and formats as
     input data. This is :math:`{}_nm_x`, the mortality rate by age group.
     Returns rates, not counts.
@@ -75,7 +76,7 @@ def asdr_as_fit_input(location_ids, sexes, gbd_round_id, ages_df, with_hiv):
     else:
         location_ids = list(location_ids)
 
-    asdr = get_asdr_data(gbd_round_id, location_ids, with_hiv)
+    asdr = get_asdr_data(gbd_round_id, decomp_step, location_ids, with_hiv)
     assert not (set(asdr.age_group_id.unique()) - set(ages_df.age_group_id.values))
     return asdr_by_sex(asdr, ages_df, sexes)
 
@@ -164,7 +165,7 @@ def load_asdr_to_t3(execution_context, data_access, location_and_children):
             f"""Uploading ASDR data for model_version_id
             {model_version_id} on '{database}'"""
         )
-        asdr_data = get_asdr_data(gbd_round_id, list(missing_from_t3), data_access.with_hiv)
+        asdr_data = get_asdr_data(gbd_round_id, data_access.decomp_step, list(missing_from_t3), data_access.with_hiv)
 
         with cursor(execution_context) as c:
             _upload_asdr_data_to_tier_3(gbd_round_id, c, model_version_id, asdr_data)

--- a/src/cascade/input_data/db/country_covariates.py
+++ b/src/cascade/input_data/db/country_covariates.py
@@ -16,12 +16,12 @@ def country_covariate_names():
     return covariate_df.to_dict()["covariate_name_short"]
 
 
-def country_covariate_set(covariate_ids, demographics, gbd_round_id):
-    return {covariate_id: country_covariates(covariate_id, demographics, gbd_round_id)
+def country_covariate_set(covariate_ids, demographics, gbd_round_id, decomp_step):
+    return {covariate_id: country_covariates(covariate_id, demographics, gbd_round_id, decomp_step)
             for covariate_id in covariate_ids}
 
 
-def country_covariates(covariate_id, demographics, gbd_round_id):
+def country_covariates(covariate_id, demographics, gbd_round_id, decomp_step):
     """Retrieve country covariates from the database. Covariates can have a
     lower value and an upper value, in addition to their mean. This returns
     only the mean of the covariate on each demographic interval.
@@ -33,6 +33,7 @@ def country_covariates(covariate_id, demographics, gbd_round_id):
             sex_ids.  The values can be int or list of ints.
         gbd_round_id (int): The number indicating which version of
             the GBD for which to retrieve these covariates.
+        decomp_step (str): Step for decomposition of transformations.
 
     Returns:
         pd.DataFrame: Columns are `covariate_id`, `covariate_name_short`,
@@ -45,7 +46,8 @@ def country_covariates(covariate_id, demographics, gbd_round_id):
         age_group_id=demographics["age_group_ids"],
         year_id=demographics["year_ids"],
         sex_id=demographics["sex_ids"],
-        gbd_round_id=gbd_round_id
+        gbd_round_id=gbd_round_id,
+        decomp_step=decomp_step,
     )[[
         "location_id", "age_group_id",
         "year_id", "sex_id", "mean_value"

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -56,7 +56,7 @@ def _gbd_process_version_id_from_cod_version(cod_version):
 
 
 def get_csmr_data(
-        execution_context, location_and_children, cause_id, cod_version, gbd_round_id):
+        execution_context, location_and_children, cause_id, cod_version, gbd_round_id, decomp_step):
     keep_cols = ["year_id", "location_id", "sex_id", "age_group_id", "val", "lower", "upper"]
 
     process_version_id = _gbd_process_version_id_from_cod_version(cod_version)
@@ -71,6 +71,7 @@ def get_csmr_data(
         measure_id=MEASURE_IDS["deaths"],
         sex_id="all",
         gbd_round_id=gbd_round_id,
+        decomp_step=decomp_step,
         process_version_id=process_version_id,
     )[keep_cols]
 

--- a/src/cascade/testing_utilities/fake_data.py
+++ b/src/cascade/testing_utilities/fake_data.py
@@ -110,7 +110,7 @@ def retrieve_fake_data(execution_context, local_settings, covariate_data_spec, r
         execution_context, local_settings.data_access, local_settings.parent_location_id, all_ages)
     data.age_specific_death_rate = asdr_as_fit_input(
         local_settings.parent_location_id, local_settings.sexes,
-        data_access.gbd_round_id, data.ages_df, with_hiv=data_access.with_hiv)
+        data_access.gbd_round_id, data_access.decomp_step, data.ages_df, with_hiv=data_access.with_hiv)
     data.study_id_to_name, data.country_id_to_name = find_covariate_names(
         execution_context, covariate_data_spec)
 

--- a/tests/input_data/configuration/test_construct_mortality.py
+++ b/tests/input_data/configuration/test_construct_mortality.py
@@ -18,6 +18,7 @@ def test_live_csmr(ihme, location_id, cause_id):
     data_access.add_csmr_cause = cause_id
     data_access.cod_version = 90
     data_access.gbd_round_id = 6
+    data_access.decomp_step = "step1"
     data_access.location_set_version_id = 429
     ages = age_spans.get_age_spans()
     raw = get_raw_csmr(ec, data_access, location_id, ages)

--- a/tests/input_data/db/test_asdr.py
+++ b/tests/input_data/db/test_asdr.py
@@ -2,6 +2,6 @@ from cascade.input_data.db.asdr import get_asdr_data
 
 
 def test_asdr_columns(ihme):
-    asdr = get_asdr_data(5, [101], with_hiv=True)
+    asdr = get_asdr_data(6, "step1", [101], with_hiv=True)
     assert not asdr.duplicated(["age_group_id", "location_id", "year_id", "sex_id"]).any()
     assert (asdr.location_id == 101).all()

--- a/tests/input_data/db/test_country_covariates.py
+++ b/tests/input_data/db/test_country_covariates.py
@@ -54,9 +54,10 @@ def demographics_default():
 def test_country_covariates_real(ihme, demographics_default):
 
     country_covariate_id = 26
-    gbd_round_id = 5
+    gbd_round_id = 6
+    decomp_step = "step1"
 
-    ccov = country_covariates(country_covariate_id, demographics_default, gbd_round_id)
+    ccov = country_covariates(country_covariate_id, demographics_default, gbd_round_id, decomp_step)
 
     assert set(ccov.columns) == {
         "location_id", "age_group_id", "year_id", "sex_id", "mean_value"}
@@ -87,8 +88,9 @@ def test_country_covariates_mock(
     mock_db_queries.get_covariate_estimates.return_value = mock_ccov_estimates
 
     country_covariate_id = 33
-    gbd_round_id = 5
+    gbd_round_id = 6
+    decomp_step = "step1"
 
     pd.testing.assert_frame_equal(
-        country_covariates(country_covariate_id, demographics_default, gbd_round_id),
+        country_covariates(country_covariate_id, demographics_default, gbd_round_id, decomp_step),
         expected_ccov, check_like=True)


### PR DESCRIPTION
…atest round of CC changes
For the user: this means the Cascade can specify both gbd_round_id and decomp step when retrieving data. The decomp step is currently listed as a policy in the policies section of the code, and it is set to step1. The gbd round ID is also a policy and is set to 6.

Brian, I'm adding you so that you see that we are GBD round 6 and decomp step "step1." and so that you know this was an impact from decomps. About 4 hours.