### PR TITLE
adding smaller requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+sphinx
+sphinx_rtd_theme
+sphinx-autobuild
+sphinxcontrib-napoleon


### PR DESCRIPTION
Docs build here but not on readthedocs.io, so adding a much smaller requirements.txt back in again.