### PR TITLE
Feature/file interface doesnt delete

### DIFF
--- a/src/cascade/dismod/db/metadata.py
+++ b/src/cascade/dismod/db/metadata.py
@@ -1,5 +1,24 @@
 """
 This describes the tables in the sqlite file that Dismod reads.
+
+Use this interface instead of raw SQL queries becasue
+
+ * It controls the data type for each column. The Sqlite
+   db doesn't say what the data type should be in Python.
+
+ * It verifies that the db has what we think it has and
+   warns us when database tables change names or when
+   columns change names.
+
+ * It lets us change a column name in the db table without
+   changing the column name we use to read it. This
+   protects us against column name changes, which are
+   freuqent.
+
+ * It records which tables depend on which other tables
+   which is necessary in order to write Pandas versions
+   to the SQL file in the right order.
+
 """
 
 import numpy as np

--- a/src/cascade/model/model.py
+++ b/src/cascade/model/model.py
@@ -45,6 +45,9 @@ class Model(DismodGroups):
         # the model. Even though avgint and data use them, a model is always
         # written before the avgint and data are written.
         self.covariates = covariates if covariates else list()
+        assert isinstance(self.covariates, list)
+        if len(self.covariates) > 0:
+            assert isinstance(self.covariates[0], Covariate)
         self._check_covariates(self.covariates)
         # There are always four weights, constant, susceptible,
         # with_condition, and total.

--- a/src/cascade/model/model_writer.py
+++ b/src/cascade/model/model_writer.py
@@ -105,7 +105,8 @@ class ModelWriter:
         if child_location is None:
             self._dismod_file.rate.loc[rate_id, "child_smooth_id"] = smooth_id
         else:
-            node_id = self._object_wrapper.location_func(child_location)
+            locs = self._object_wrapper.locations
+            node_id = locs[locs.location_id == child_location].node_id.item()
             if rate_name not in self._nslist:
                 ns_id = len(self._nslist)
                 self._nslist[rate_name] = ns_id

--- a/src/cascade/model/model_writer.py
+++ b/src/cascade/model/model_writer.py
@@ -2,7 +2,6 @@
 Writes a Model to a Dismod File.
 """
 from math import nan, inf
-from numbers import Real
 
 import numpy as np
 import pandas as pd
@@ -45,7 +44,6 @@ class ModelWriter:
         self._rate_id = dict()  # The rate ids with the primary rates.
         self._nslist = dict()  # rate to integer
         self._nslist_pair_rows = list()  # list of nslist id, node, and smooth
-        self._covariate_id_func = lambda x: nan
         self._flushed = False
         self._children = None
         self._clear_previous_model()
@@ -129,7 +127,7 @@ class ModelWriter:
             "mulcov_type": MulCovEnum[kind].value,
             "rate_id": nan,
             "integrand_id": nan,
-            "covariate_id": self._covariate_id_func(covariate),
+            "covariate_id": self._object_wrapper.covariate_to_index[covariate],
             "smooth_id": self.add_random_field(grid_name, random_field),
         }
         if kind == "alpha":
@@ -323,43 +321,4 @@ class ModelWriter:
         for remaining in sorted(lookup.keys()):
             reorder.append(lookup[remaining])
         CODELOG.debug(f"covariates {', '.join(c.name for c in reorder)}")
-        covariate_df, cov_col_id_func, covariate_renames = _make_covariate_table(reorder)
-        self._dismod_file.update_table_columns("covariate", covariate_df)
-        self._dismod_file.covariate = covariate_df
-        self._covariate_id_func = cov_col_id_func
-        self._object_wrapper.covariate_rename = covariate_renames
-
-
-def _make_covariate_table(covariates):
-    null_references = list()
-    for check_ref_col in covariates:
-        if not isinstance(check_ref_col.reference, Real):
-            null_references.append(check_ref_col.name)
-    if null_references:
-        raise ValueError(f"Covariate columns without reference values {null_references}")
-
-    # Dismod requires us to rename covariates from names like sex, and "one"
-    # to x_0, x_1,... They must be "x_<digit>".
-    renames = dict()
-    for cov_idx, covariate in enumerate(covariates):
-        renames[covariate.name] = f"x_{cov_idx}"
-
-    covariate_columns = pd.DataFrame(
-        {
-            "covariate_id": np.arange(len(covariates)),
-            "covariate_name": [col.name for col in covariates],
-            "reference": np.array([col.reference for col in covariates], dtype=np.float),
-            "max_difference": np.array([col.max_difference for col in covariates], dtype=np.float),
-        }
-    )
-
-    def cov_col_id_func(query_column):
-        """From the original covariate name to the index in SQL file."""
-        try:
-            covariate_id = [search.name for search in covariates].index(query_column)
-        except ValueError as ve:
-            if "is not in list" in str(ve):
-                raise ValueError(f"A covariate was not registered with the model. {ve}")
-        return covariate_id
-
-    return covariate_columns, cov_col_id_func, renames
+        self._object_wrapper.covariates = reorder

--- a/src/cascade/model/object_wrapper.py
+++ b/src/cascade/model/object_wrapper.py
@@ -139,7 +139,7 @@ class ObjectWrapper:
         if len(records) == 1:
             return records.option_value.item()
         else:
-            return None
+            raise KeyError(f"Option {name} not found in options")
 
     @property
     def data(self):

--- a/src/cascade/model/object_wrapper.py
+++ b/src/cascade/model/object_wrapper.py
@@ -26,6 +26,11 @@ class ObjectWrapper:
     """
     An I/O layer on top of the Dismod db file that presents Model objects.
     It sets and gets models, vars, data, and residuals.
+
+    It takes work to ensure that all the database records are
+    consistent. This class groups sets of tables and columns
+    within those tables into higher-level objects that are then
+    easier to reason about.
     """
     def __init__(self, locations, parent_location, filename):
         assert isinstance(locations, pd.DataFrame)

--- a/src/cascade/model/session.py
+++ b/src/cascade/model/session.py
@@ -45,7 +45,7 @@ class Session:
         assert isinstance(parent_location, int)
         assert isinstance(filename, (Path, str))
 
-        self._filename = filename
+        self._filename = Path(filename)
         if self._filename.exists():
             CODELOG.info(f"{self._filename} exists so overwriting it.")
             self._filename.unlink()

--- a/src/cascade/model/session.py
+++ b/src/cascade/model/session.py
@@ -46,7 +46,12 @@ class Session:
         assert isinstance(filename, (Path, str))
 
         self._filename = filename
-        self._objects = ObjectWrapper(locations, parent_location, filename)
+        if self._filename.exists():
+            CODELOG.info(f"{self._filename} exists so overwriting it.")
+            self._filename.unlink()
+        self._objects = ObjectWrapper(filename)
+        self._objects.locations = locations
+        self._objects.parent_location_id = parent_location
         self._options = dict()
 
     def fit(self, model, data, initial_guess=None):


### PR DESCRIPTION
This changes the DismodObjects layer so that it doesn't delete the file automatically.
The goal is to make it easier to attach and detach from existing files instead of rewriting files from a model each time we want to run a simulation. This PR removes internal state from the DismodObjects file so that there are no side-effects that require keeping the same DismodObjects open while working with a Dismod-AT db file.