### PR TITLE
Feature/download data early

### DIFF
--- a/docs/epiviz/dmcascade.rst
+++ b/docs/epiviz/dmcascade.rst
@@ -85,8 +85,8 @@ The study covariates file must have the following columns: seq (must match the i
 
 .. option:: --skip-cache
 
-    Download all data from the databases, instead of going to tier 3, which
-    is a version stored in order to ensure repeatable runs. This flag
+    Download all data directly from the databases, instead of going to tier 3,
+    which is a version stored in order to ensure repeatable runs. This flag
     also turns off creation of a tier 3 copy of data.
 
 .. option:: --num-processes NUM_PROCESSES

--- a/src/cascade/executor/cascade_plan.py
+++ b/src/cascade/executor/cascade_plan.py
@@ -2,6 +2,7 @@
 Specification for what parameters are used at what location within
 the Cascade.
 """
+from os import linesep
 from types import SimpleNamespace
 
 import networkx as nx
@@ -12,6 +13,7 @@ from cascade.input_data import InputDataError
 from cascade.input_data.configuration.builder import policies_from_settings
 from cascade.input_data.configuration.sex import SEX_ID_TO_NAME, SEX_NAME_TO_ID
 from cascade.input_data.db.locations import location_id_from_start_and_finish
+from cascade.runner.application_config import application_config
 from cascade.runner.job_graph import RecipeIdentifier
 
 CODELOG, MATHLOG = getLoggers(__name__)
@@ -118,6 +120,11 @@ def recipe_graph_from_settings(locations, settings, args):
     for recipe_identifier in recipe_graph.nodes:
         local_settings = location_specific_settings(locations, settings, args, recipe_identifier)
         recipe_graph.nodes[recipe_identifier]["local_settings"] = local_settings
+
+    if len(recipe_graph) < application_config()["NonModel"].getint("small-graph-nodes"):
+        debug_lines = [str(node) for node in nx.topological_sort(recipe_graph)]
+        debug_str = f"{linesep}\t".join(debug_lines)
+        CODELOG.debug(f"Recipes in order{linesep}\t{debug_str}")
 
     return recipe_graph
 

--- a/src/cascade/executor/cascade_plan.py
+++ b/src/cascade/executor/cascade_plan.py
@@ -138,10 +138,7 @@ def drill_recipe_graph(locations, settings, args):
     MATHLOG.info(f"drill nodes {', '.join(str(d) for d in drill)}")
     drill = list(drill)
     drill_sex = SEX_ID_TO_NAME[settings.model.drill_sex]
-    if args.skip_cache:
-        setup_task = []
-    else:
-        setup_task = [RecipeIdentifier(0, "bundle_setup", drill_sex)]
+    setup_task = [RecipeIdentifier(0, "bundle_setup", drill_sex)]
     recipes = setup_task + [
         RecipeIdentifier(drill_location, "estimate_location", drill_sex)
         for drill_location in drill
@@ -176,12 +173,9 @@ def global_recipe_graph(locations, settings, args):
     global_node = RecipeIdentifier(locations.graph["root"], "estimate_location", "both")
     recipe_graph = nx.DiGraph(root=global_node)
     # Start with bundle setup
-    if not args.skip_cache:
-        bundle_setup = RecipeIdentifier(0, "bundle_setup", "both")
-        recipe_graph.graph["root"] = bundle_setup
-        recipe_graph.add_edge(bundle_setup, global_node)
-    else:
-        recipe_graph.graph["root"] = global_node
+    bundle_setup = RecipeIdentifier(0, "bundle_setup", "both")
+    recipe_graph.graph["root"] = bundle_setup
+    recipe_graph.add_edge(bundle_setup, global_node)
 
     global_recipe_graph_add_estimations(locations, recipe_graph, split_sex)
 

--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -115,7 +115,14 @@ def constrain_omega(default_age_time, asdr, ev_settings, model, parent_location_
         parent_location_id (int): parent location
         children (List[int]): Child location ids.
     """
-    omega = rectangular_data_to_var(asdr[asdr.location == parent_location_id])
+    parent_asdr = asdr[asdr.location == parent_location_id]
+    if len(parent_asdr) == 0:
+        raise RuntimeError(
+            f"Age-specific death rate has no values for this location "
+            f"({parent_location_id}). It has locations "
+            f"{', '.join(str(x) for x in asdr.location.unique())}."
+        )
+    omega = rectangular_data_to_var(parent_asdr)
     model.rate["omega"] = constraint_from_rectangular_data(omega, default_age_time)
     asdr_locations = set(asdr.location.unique().tolist())
     children_without_asdr = set(children) - set(asdr_locations)

--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -143,6 +143,8 @@ def constrain_omega(default_age_time, asdr, ev_settings, model, parent_location_
             single_sex_asdr = asdr[asdr.sex_id == keep]
         else:
             raise AssertionError(f"ASDR had sexes {sexes_present}.")
+    else:
+        single_sex_asdr = asdr
 
     parent_asdr = single_sex_asdr[single_sex_asdr.location == parent_location_id]
     if len(parent_asdr) == 0:

--- a/src/cascade/executor/construct_model.py
+++ b/src/cascade/executor/construct_model.py
@@ -15,13 +15,24 @@ def rectangular_data_to_var(gridded_data):
     """Using this very regular data, where every age and time is present,
     construct an initial guess as a Var object. Very regular means that there
     is a complete set of ages-cross-times."""
-    initial_ages = np.sort(np.unique(0.5 * (gridded_data.age_lower + gridded_data.age_upper)))
-    initial_times = np.sort(np.unique(0.5 * (gridded_data.time_lower + gridded_data.time_upper)))
+    try:
+        initial_ages = np.sort(
+            np.unique(0.5 * (gridded_data.age_lower + gridded_data.age_upper))
+        )
+        initial_times = np.sort(
+            np.unique(0.5 * (gridded_data.time_lower + gridded_data.time_upper))
+        )
+    except AttributeError:
+        CODELOG.error(f"Data to make a var has columns {gridded_data.columns}")
+        raise RuntimeError(
+            f"Wrong columns in rectangular_data_to_var {gridded_data.columns}")
 
     guess = Var(ages=initial_ages, times=initial_times)
     for age, time in guess.age_time():
         found = gridded_data.query(
-            "(age_lower <= @age) & (@age <= age_upper) & (time_lower <= @time) & (@time <= time_upper)")
+            "(age_lower <= @age) & (@age <= age_upper) & "
+            "(time_lower <= @time) & (@time <= time_upper)"
+        )
         assert len(found) == 1, f"found {found}"
         guess[age, time] = float(found.iloc[0]["mean"])
     return guess
@@ -81,10 +92,10 @@ def construct_model(data, local_settings, covariate_multipliers, covariate_data_
     if children and len(children) > 1:
         construct_model_random_effects(default_age_time, single_age_time, ev_settings, model)
     construct_model_covariates(default_age_time, single_age_time, covariate_multipliers, model)
+    asdr = data.age_specific_death_rate
     if ev_settings.model.constrain_omega:
         constrain_omega(
-            default_age_time, data.age_specific_death_rate,
-            ev_settings, model, parent_location_id, children
+            default_age_time, asdr, ev_settings, model, parent_location_id, children
         )
 
     return model
@@ -115,16 +126,35 @@ def constrain_omega(default_age_time, asdr, ev_settings, model, parent_location_
         parent_location_id (int): parent location
         children (List[int]): Child location ids.
     """
-    parent_asdr = asdr[asdr.location == parent_location_id]
+    CODELOG.debug(
+        f"Constrain omega, asdr columns {asdr.columns} "
+        f"parent loc {parent_location_id} child locs {children}.")
+    sexes_present = set(asdr.sex_id.unique())
+    if len(sexes_present) > 1:
+        if sexes_present == {1, 2}:
+            # XXX use population weighting
+            axes = ["time_lower", "time_upper", "age_lower", "age_upper", "location"]
+            gridded_data = asdr[axes + ["mean"]]
+            single_sex_asdr = gridded_data.groupby(axes).mean().reset_index()
+        elif sexes_present == {1, 2, 3}:
+            single_sex_asdr = asdr[asdr.sex_id == 3]
+        elif 3 in sexes_present:
+            keep = (sexes_present - {3}).pop()
+            single_sex_asdr = asdr[asdr.sex_id == keep]
+        else:
+            raise AssertionError(f"ASDR had sexes {sexes_present}.")
+
+    parent_asdr = single_sex_asdr[single_sex_asdr.location == parent_location_id]
     if len(parent_asdr) == 0:
         raise RuntimeError(
             f"Age-specific death rate has no values for this location "
             f"({parent_location_id}). It has locations "
-            f"{', '.join(str(x) for x in asdr.location.unique())}."
+            f"{', '.join(str(x) for x in single_sex_asdr.location.unique())}."
         )
+
     omega = rectangular_data_to_var(parent_asdr)
     model.rate["omega"] = constraint_from_rectangular_data(omega, default_age_time)
-    asdr_locations = set(asdr.location.unique().tolist())
+    asdr_locations = set(single_sex_asdr.location.unique().tolist())
     children_without_asdr = set(children) - set(asdr_locations)
     if children_without_asdr:
         MATHLOG.warning(f"Children of {parent_location_id} missing ASDR {children_without_asdr} "
@@ -132,7 +162,7 @@ def constrain_omega(default_age_time, asdr, ev_settings, model, parent_location_
         return
 
     for child in children:
-        child_asdr = asdr[asdr.location == child]
+        child_asdr = single_sex_asdr[single_sex_asdr.location == child]
         assert len(child_asdr) > 0
         child_rate = rectangular_data_to_var(child_asdr)
 

--- a/src/cascade/executor/covariate_data.py
+++ b/src/cascade/executor/covariate_data.py
@@ -49,9 +49,13 @@ def add_covariate_data_to_observations_and_avgints(data, local_settings, epiviz_
     # Assign all of the names. Study covariates aren't ever transformed.
     for name_covariate in epiviz_covariates:
         if name_covariate.study_country == "study":
-            short = data.study_id_to_name[name_covariate.covariate_id]
+            short = data.study_id_to_name.get(name_covariate.covariate_id, None)
         else:
-            short = data.country_id_to_name[name_covariate.covariate_id]
+            short = data.country_id_to_name.get(name_covariate.covariate_id, None)
+        if short is None:
+            raise RuntimeError(
+                f"Covariate {name_covariate} is not found in id-to-name mapping."
+            )
         name_covariate.untransformed_covariate_name = short
 
     add_study_covariate_to_observations_and_avgints(data)

--- a/src/cascade/executor/covariate_data.py
+++ b/src/cascade/executor/covariate_data.py
@@ -46,8 +46,6 @@ def add_covariate_data_to_observations_and_avgints(data, local_settings, epiviz_
     Returns:
         None: Everything is added to observations and avgints.
     """
-    assign_epiviz_covariate_names(data, epiviz_covariates)
-
     add_study_covariate_to_observations_and_avgints(data)
     add_country_covariate_to_observations_and_avgints(data, local_settings, epiviz_covariates)
 

--- a/src/cascade/executor/covariate_data.py
+++ b/src/cascade/executor/covariate_data.py
@@ -46,20 +46,24 @@ def add_covariate_data_to_observations_and_avgints(data, local_settings, epiviz_
     Returns:
         None: Everything is added to observations and avgints.
     """
+    assign_epiviz_covariate_names(data, epiviz_covariates)
+
+    add_study_covariate_to_observations_and_avgints(data)
+    add_country_covariate_to_observations_and_avgints(data, local_settings, epiviz_covariates)
+
+
+def assign_epiviz_covariate_names(study_id_to_name, country_id_to_name, epiviz_covariates):
     # Assign all of the names. Study covariates aren't ever transformed.
     for name_covariate in epiviz_covariates:
         if name_covariate.study_country == "study":
-            short = data.study_id_to_name.get(name_covariate.covariate_id, None)
+            short = study_id_to_name.get(name_covariate.covariate_id, None)
         else:
-            short = data.country_id_to_name.get(name_covariate.covariate_id, None)
+            short = country_id_to_name.get(name_covariate.covariate_id, None)
         if short is None:
             raise RuntimeError(
                 f"Covariate {name_covariate} is not found in id-to-name mapping."
             )
         name_covariate.untransformed_covariate_name = short
-
-    add_study_covariate_to_observations_and_avgints(data)
-    add_country_covariate_to_observations_and_avgints(data, local_settings, epiviz_covariates)
 
 
 def add_country_covariate_to_observations_and_avgints(data, local_settings, epiviz_covariates):

--- a/src/cascade/executor/covariate_description.py
+++ b/src/cascade/executor/covariate_description.py
@@ -28,7 +28,11 @@ class EpiVizCovariate:
     def name(self):
         """The name for this covariate in the final data."""
         if self.untransformed_covariate_name is None:
-            raise RuntimeError(f"The name for this covariate hasn't been set yet {self.covariate_id}")
+            raise RuntimeError(
+                f"The name for this covariate hasn't been set yet "
+                f"id={self.covariate_id}, {self.study_country}, "
+                f"transform={self.transformation_id}."
+            )
         transform_name = COVARIATE_TRANSFORMS[self.transformation_id].__name__
         if transform_name != "identity":
             return f"{self.untransformed_covariate_name}_{transform_name}"

--- a/src/cascade/executor/covariate_description.py
+++ b/src/cascade/executor/covariate_description.py
@@ -7,7 +7,11 @@ from cascade.input_data.configuration.builder import COVARIATE_TRANSFORMS
 
 @total_ordering
 class EpiVizCovariate:
-    """This specifies covariate data from settings."""
+    """This specifies covariate data from settings.
+    It is separate from the cascade.model.Covariate, which is a Dismod-AT
+    covariate. EpiViz-AT distinguishes study and country covariates and
+    encodes them into the Dismod-AT covariate names.
+    """
     def __init__(self, study_country, covariate_id, transformation_id):
         self.study_country = study_country
         self.covariate_id = covariate_id

--- a/src/cascade/executor/create_settings.py
+++ b/src/cascade/executor/create_settings.py
@@ -238,10 +238,10 @@ def create_settings(choices, locations=None):
     last_location = list(nx.topological_sort(locations))[-1]
     drill = sorted(nx.ancestors(locations, last_location))
     start_loc = rng.choice(list(range(len(drill))), name="drill_start")
-    print(f"drill {drill}")
     end_loc = rng.choice(list(range(len(drill[start_loc:]))), name="drill_end")
     case["model"]["drill_location_start"] = drill[start_loc]
     case["model"]["drill_location_end"] = drill[start_loc:][end_loc]
+    print(f"drill {drill} with start {drill[start_loc]} end {drill[start_loc:][end_loc]}")
 
     rate_specifies_re_by_location = which_random_effects(nonzero_rates, rate, rng)
 

--- a/src/cascade/executor/data/config.cfg
+++ b/src/cascade/executor/data/config.cfg
@@ -8,3 +8,9 @@ code-log-directory = codelog"
 corporate-odbc = /corporate/shared
 personal-odbc = ~/.odbc.ini
 local-odbc = /corporate/copied/odbc
+
+
+[NonModel]
+small-graph-nodes = 10
+small-location-count = 100
+locations-per-query = 8

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -151,6 +151,15 @@ def modify_input_data(input_data, local_settings):
 
 
 def one_location_data_from_global_data(global_data, local_settings):
+    include_birth_prevalence = local_settings.settings.model.birth_prev
+    global_data.average_integrand_cases = \
+        make_average_integrand_cases_from_gbd(
+            global_data.ages_df,
+            global_data.years_df,
+            local_settings.sexes,
+            local_settings.children,
+            include_birth_prevalence
+        )
     # subset asdr
     # subset csmr
     add_covariate_data_to_observations_and_avgints(global_data, local_settings, global_data.covariate_data_spec)
@@ -163,16 +172,6 @@ def one_location_data_from_global_data(global_data, local_settings):
     # The parent can also supply integrands as a kind of prior.
     # These will be shaped like input measurement data. Called fit-integrands.
     global_data.integrands = None
-
-    include_birth_prevalence = local_settings.settings.model.birth_prev
-    global_data.average_integrand_cases = \
-        make_average_integrand_cases_from_gbd(
-            global_data.ages_df,
-            global_data.years_df,
-            local_settings.sexes,
-            local_settings.children,
-            include_birth_prevalence
-        )
     return global_data
 
 

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -48,6 +48,7 @@ def retrieve_data(execution_context, local_settings, covariate_data_spec):
             bundle_id=local_settings.data_access.bundle_id,
             tier=local_settings.data_access.tier
         )
+    CODELOG.debug(f"Bundle length {len(data.bundle)} ")
     # Study covariates will have columns {"bundle_id", "seq", "study_covariate_id"}.
     if data_access.bundle_study_covariates_file:
         data.sparse_covariate_data = dataframe_from_disk(data_access.bundle_study_covariates_file)

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -151,7 +151,21 @@ def modify_input_data(input_data, local_settings):
 
 
 def one_location_data_from_global_data(global_data, local_settings):
+    """
+    Responsible for localizing global data to this location and its children.
+    The global data has been saved, for all locations, earlier. This
+    looks at settings and subselects that data.
+
+    Args:
+        global_data (SimpleNamespace): A bag of data.
+        local_settings (SimpleNamespace): Settings that have been build
+            for this location.
+
+    Returns:
+        SimpleNamespace: The same object, but data is modified.
+    """
     include_birth_prevalence = local_settings.settings.model.birth_prev
+    # Make avgints here b/c they are wrote and not worth saving.
     global_data.average_integrand_cases = \
         make_average_integrand_cases_from_gbd(
             global_data.ages_df,
@@ -160,7 +174,6 @@ def one_location_data_from_global_data(global_data, local_settings):
             local_settings.children,
             include_birth_prevalence
         )
-    # subset csmr
     add_covariate_data_to_observations_and_avgints(global_data, local_settings, global_data.covariate_data_spec)
     global_data.observations = global_data.observations.drop(columns=["sex_id", "seq"])
     set_sex_reference(global_data.covariate_data_spec, local_settings)

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -160,7 +160,6 @@ def one_location_data_from_global_data(global_data, local_settings):
             local_settings.children,
             include_birth_prevalence
         )
-    # subset asdr
     # subset csmr
     add_covariate_data_to_observations_and_avgints(global_data, local_settings, global_data.covariate_data_spec)
     global_data.observations = global_data.observations.drop(columns=["sex_id", "seq"])

--- a/src/cascade/executor/job_definitions.py
+++ b/src/cascade/executor/job_definitions.py
@@ -186,6 +186,7 @@ class ConstructDraw(CascadeJob):
         self.inputs.update(dict(
             db_file=DbFile(execution_context, "fit.db", parent_location_id, recipe_id.sex),
         ))
+        # self.task_id will be defined for a task created from a job.
         if self.task_id is not None:
             draw_idx = self.task_id
             self.outputs[f"db_file{draw_idx}"] = DbFile(
@@ -195,9 +196,6 @@ class ConstructDraw(CascadeJob):
             for draw_idx in range(1, 1 + draw_cnt):
                 draw_file = DbFile(execution_context, f"draw{draw_idx}.db", parent_location_id, recipe_id.sex)
                 self.outputs[f"draw_file{draw_idx}"] = draw_file
-
-    def clone_task(self, task_id):
-        return super().clone_task(task_id)
 
     def run_under_mathlog(self):
         draw_db = self.outputs[f"draw_file{self.task_id}"].path

--- a/src/cascade/executor/job_definitions.py
+++ b/src/cascade/executor/job_definitions.py
@@ -59,6 +59,11 @@ def read_global_for_location(global_vars_path, global_data_path):
 
 
 class GlobalPrepareData(CascadeJob):
+    """
+    This job reads settings and downloads all data that will be needed by
+    every later location in the Cascade. The goal is to do all database
+    queries here and store the results in a single directory.
+    """
     def __init__(self, recipe_id, local_settings, execution_context):
         super().__init__("global_prepare", recipe_id, local_settings, execution_context)
         global_location = 0
@@ -91,7 +96,11 @@ class GlobalPrepareData(CascadeJob):
 
 
 class FindSingleMAP(CascadeJob):
-    """Run the fit without any pre-fit."""
+    """
+    This job does an estimation for a single location.
+    It takes parent data and does a single fit without preceding that
+    with a "fit fixed" in order to estimate the starting fit.
+    """
     def __init__(self, recipe_id, local_settings, recipe_graph_neighbors, execution_context):
         super().__init__("find_single_maximum", recipe_id, local_settings, execution_context)
         global_location = 0
@@ -138,7 +147,11 @@ class FindSingleMAP(CascadeJob):
 
 
 class FindFixedMAP(CascadeJob):
-    """Do a "fit fixed" which will precede the "fit both"."""
+    """
+    Do a "fit fixed" which will precede the "fit both".
+    The "fit fixed" is much faster than fit both. It is used to find an
+    initial guess to use for scaling the later fit with random effects.
+    """
     def __init__(self, recipe_id, local_settings, neighbors, execution_context):
         super().__init__("find_maximum_fixed", recipe_id, local_settings, execution_context)
         global_location = 0

--- a/src/cascade/executor/job_definitions.py
+++ b/src/cascade/executor/job_definitions.py
@@ -1,16 +1,20 @@
+import shelve
 from contextlib import closing
 from inspect import getmembers
-import shelve
+from shutil import copyfile
+from types import SimpleNamespace
 
 import pandas as pd
 
 from cascade.core import getLoggers
-from cascade.dismod import DismodATException
 from cascade.executor.cascade_plan import recipe_graph_from_settings
 from cascade.executor.construct_model import construct_model
 from cascade.executor.covariate_description import create_covariate_specifications
-from cascade.executor.estimate_location import retrieve_data, modify_input_data, compute_parent_fit_fixed, \
-    compute_parent_fit, make_draws, save_outputs
+from cascade.executor.estimate_location import (
+    retrieve_data, modify_input_data, compute_parent_fit_fixed,
+    compute_parent_fit, gather_simulations_and_fit, save_outputs,
+    one_location_data_from_global_data,
+)
 from cascade.executor.priors_from_draws import set_priors_from_parent_draws
 from cascade.input_data.configuration.raw_input import validate_input_data_types
 from cascade.runner.data_passing import ShelfFile, PandasFile, DbFile
@@ -41,6 +45,19 @@ def save_global_data_to_hdf(path, global_data):
     return not_written
 
 
+def read_global_for_location(global_vars_path, global_data_path):
+    global_data = SimpleNamespace
+    with closing(pd.HDFStore(str(global_data_path), "r")) as retrieve:
+        for df_name in retrieve.keys():
+            setattr(global_data, df_name, retrieve.get(df_name))
+
+    with shelve.open(global_vars_path, "r") as shelf:
+        for key in shelf.keys():
+            setattr(global_data, key, shelf[key])
+
+    return global_data
+
+
 class GlobalPrepareData(CascadeJob):
     def __init__(self, recipe_id, local_settings, execution_context):
         super().__init__("global_prepare", recipe_id, local_settings, execution_context)
@@ -62,7 +79,7 @@ class GlobalPrepareData(CascadeJob):
         input_data = retrieve_data(execution_context, local_settings, covariate_data_spec)
         columns_wrong = validate_input_data_types(input_data)
         assert not columns_wrong, f"validation failed {columns_wrong}"
-        modified_data = modify_input_data(input_data, local_settings, covariate_data_spec)
+        modified_data = modify_input_data(input_data, local_settings)
         not_written = save_global_data_to_hdf(self.outputs["data"].path, modified_data)
 
         with shelve.open(str(self.outputs["shared"].path)) as shared:
@@ -99,7 +116,13 @@ class FindFixedMAP(CascadeJob):
     """Do a "fit fixed" which will precede the "fit both"."""
     def __init__(self, recipe_id, local_settings, neighbors, execution_context):
         super().__init__("find_maximum_fixed", recipe_id, local_settings, execution_context)
-        self.inputs["input_data"] = PandasFile(execution_context, "globaldata.hdf", 0, "both")
+        global_location = 0
+        self.inputs.update(dict(
+            global_shared=ShelfFile(execution_context, "globalvars", global_location, "both", required_keys=[
+                "covariate_multipliers", "covariate_data_spec",
+            ]),
+            global_data=PandasFile(execution_context, "globaldata.hdf", global_location, "both"),
+        ))
         parent_location_id = local_settings.parent_location_id
         estimation_parent = [
             predecessor for predecessor in neighbors["predecessors"]
@@ -113,6 +136,27 @@ class FindFixedMAP(CascadeJob):
             )
         self.outputs["db_file"] = DbFile(execution_context, "fit.db", parent_location_id, recipe_id.sex)
 
+    def run_under_mathlog(self):
+        global_data = read_global_for_location(
+            self.inputs["global_shared"].path,
+            self.inputs["global_data"].path,
+        )
+        modified_data = one_location_data_from_global_data(global_data, self.local_settings)
+        model = construct_model(
+            modified_data,
+            self.local_settings,
+            modified_data.covariate_multipliers,
+            modified_data.covariate_data_spec
+        )
+        set_priors_from_parent_draws(model, modified_data.draws)
+        compute_parent_fit_fixed(
+            self.execution_context,
+            self.outputs["db_file"].path,
+            self.local_settings,
+            modified_data,
+            model,
+        )
+
 
 class FindBothMAP(CascadeJob):
     """Do a "fit both" assuming a "fit fixed" was done first."""
@@ -120,12 +164,18 @@ class FindBothMAP(CascadeJob):
         super().__init__("find_maximum_both", recipe_id, local_settings, execution_context)
         parent_location_id = local_settings.parent_location_id
         self.inputs.update(dict(
-            input_data=PandasFile(execution_context, "globaldata.hdf", 0, "both"),
             db_file=DbFile(execution_context, "fit.db", parent_location_id, recipe_id.sex),
         ))
         self.outputs.update(dict(
             db_file=DbFile(execution_context, "fit.db", parent_location_id, recipe_id.sex),
         ))
+
+    def run_under_mathlog(self):
+        compute_parent_fit(
+            self.execution_context,
+            self.inputs["db_file"].path,
+            self.local_settings,
+        )
 
 
 class ConstructDraw(CascadeJob):
@@ -136,10 +186,22 @@ class ConstructDraw(CascadeJob):
         self.inputs.update(dict(
             db_file=DbFile(execution_context, "fit.db", parent_location_id, recipe_id.sex),
         ))
-        draw_cnt = local_settings.number_of_fixed_effect_samples
-        for draw_idx in range(draw_cnt):
-            draw_file = DbFile(execution_context, f"draw{draw_idx}.db", parent_location_id, recipe_id.sex)
-            self.outputs[f"db_file{draw_idx}"] = draw_file
+        if self.task_id is not None:
+            draw_idx = self.task_id
+            self.outputs[f"db_file{draw_idx}"] = DbFile(
+                execution_context, f"draw{draw_idx}.db", parent_location_id, recipe_id.sex)
+        else:
+            draw_cnt = local_settings.number_of_fixed_effect_samples
+            for draw_idx in range(1, 1 + draw_cnt):
+                draw_file = DbFile(execution_context, f"draw{draw_idx}.db", parent_location_id, recipe_id.sex)
+                self.outputs[f"draw_file{draw_idx}"] = draw_file
+
+    def clone_task(self, task_id):
+        return super().clone_task(task_id)
+
+    def run_under_mathlog(self):
+        draw_db = self.outputs[f"draw_file{self.task_id}"].path
+        copyfile(self.inputs["db_file"].path, draw_db)
 
 
 class Summarize(CascadeJob):
@@ -149,99 +211,26 @@ class Summarize(CascadeJob):
         parent_location_id = local_settings.parent_location_id
         draw_cnt = local_settings.number_of_fixed_effect_samples
         self.inputs.update(dict(
-            input_data=PandasFile(execution_context, "globaldata.hdf", 0, "both"),
             db_file=DbFile(execution_context, "fit.db", parent_location_id, recipe_id.sex),
         ))
         for draw_idx in range(draw_cnt):
             draw_file = DbFile(execution_context, f"draw{draw_idx}.db", parent_location_id, recipe_id.sex)
-            self.inputs[f"db_file{draw_idx}"] = draw_file
+            self.inputs[f"draw_file{draw_idx}"] = draw_file
         self.outputs.update(dict(
             summary=PandasFile(execution_context, "summary.hdf", parent_location_id, recipe_id.sex)
         ))
 
-
-class EstimateLocationPrepareData(CascadeJob):
-    def __call__(self, execution_context):
-        """
-        Estimates rates for a single location in the location hierarchy.
-        This does multiple fits and predictions in order to estimate uncertainty.
-
-        Args:
-            execution_context: Describes environment for this process.
-            local_settings: A dictionary describing the work to do. This has
-                a location ID corresponding to the location for this fit.
-        """
-        local_settings = self.local_settings
-        covariate_multipliers, covariate_data_spec = create_covariate_specifications(
-            local_settings.settings.country_covariate, local_settings.settings.study_covariate
+    def run_under_mathlog(self):
+        fit_result, predictions = gather_simulations_and_fit(
+            self.inputs["db_file"].path,
+            [self.inputs[draw].path for draw in self.inputs if draw.startswith("draw")]
         )
-        shared = shelve.open(str(self.outputs["shared"].path(execution_context)))
-        shared["covariate_multipliers"] = covariate_multipliers
-        shared["covariate_data_spec"] = covariate_data_spec
-        input_data = retrieve_data(execution_context, local_settings, covariate_data_spec)
-        columns_wrong = validate_input_data_types(input_data)
-        assert not columns_wrong, f"validation failed {columns_wrong}"
-        grandparent = shelve.open(str(self.inputs["grandparent_shared"].path(execution_context)))
-        modified_data = modify_input_data(input_data, local_settings, covariate_data_spec, grandparent)
-        shared["prepared_input_data"] = modified_data
-
-
-class EstimateLocationConstructModel(CascadeJob):
-    def __call__(self, execution_context, local_settings, local_cache):
-        covariate_multipliers = local_cache.get("covariate_multipliers:{local_settings.parent_location_id}")
-        covariate_data_spec = local_cache.get("covariate_data_spec:{local_settings.parent_location_id}")
-        modified_data = local_cache.get("prepared_input_data:{local_settings.parent_location_id}")
-        model = construct_model(modified_data, local_settings, covariate_multipliers,
-                                covariate_data_spec)
-        set_priors_from_parent_draws(model, modified_data.draws)
-        local_cache.set("prepared_model:{local_settings.parent_location_id}", model)
-
-
-class EstimateLocationInitialGuess(CascadeJob):
-    def __call__(self, execution_context, local_settings, local_cache):
-        model = local_cache.get("prepared_model:{local_settings.parent_location_id}")
-        input_data = local_cache.get("prepared_input_data:{local_settings.parent_location_id}")
-        initial_guess = local_cache.get("parent_initial_guess:{local_settings.parent_location_id}")
-        fit_result = compute_parent_fit_fixed(execution_context, local_settings, input_data, model, initial_guess)
-        local_cache.set("parent_initial_guess:{local_settings.parent_location_id}", fit_result.fit)
-
-
-class EstimateLocationInitialFit(CascadeJob):
-    def __call__(self, execution_context, local_settings, local_cache):
-        model = local_cache.get("prepared_model:{local_settings.parent_location_id}")
-        input_data = local_cache.get("prepared_input_data:{local_settings.parent_location_id}")
-        initial_guess = local_cache.get("parent_initial_guess:{local_settings.parent_location_id}")
-        fit_result = compute_parent_fit(execution_context, local_settings, input_data, model, initial_guess)
-        local_cache.set("parent_fit:{local_settings.parent_location_id}", fit_result)
-
-
-class EstimateLocationComputeDraws(CascadeJob):
-    def __call__(self, execution_context, local_settings, local_cache):
-        model = local_cache.get("prepared_model:{local_settings.parent_location_id}")
-        fit_result = local_cache.get("parent_fit:{local_settings.parent_location_id}")
-        input_data = local_cache.get("prepared_input_data:{local_settings.parent_location_id}")
-        draws = make_draws(
-            execution_context,
-            model,
-            input_data,
-            fit_result.fit,
-            local_settings,
-            execution_context.parameters.num_processes
+        save_outputs(
+            fit_result,
+            predictions,
+            self.execution_context,
+            self.local_settings,
         )
-        if draws:
-            draws, predictions = zip(*draws)
-            local_cache.set(f"fit-draws:{local_settings.parent_location_id}", draws)
-            local_cache.set(f"fit-predictions:{local_settings.parent_location_id}", predictions)
-        else:
-            raise DismodATException("Fit failed for all samples")
-
-
-class EstimateLocationSavePredictions(CascadeJob):
-    def __call__(self, execution_context, local_settings, local_cache):
-        if not local_settings.run.no_upload:
-            predictions = local_cache.get(f"fit-predictions:{local_settings.parent_location_id}")
-            fit_result = local_cache.get("parent_fit:{local_settings.parent_location_id}")
-            save_outputs(fit_result, predictions, execution_context, local_settings)
 
 
 def recipe_to_jobs(recipe_identifier, local_settings, neighbors, execution_context):

--- a/src/cascade/executor/job_definitions.py
+++ b/src/cascade/executor/job_definitions.py
@@ -344,6 +344,7 @@ def add_job_list(recipe_graph, execution_context):
     # graph to run. It's important for testing.
     included_locations = {
         recipe_id.location_id for recipe_id in recipe_graph.nodes
+        if recipe_id.location_id != 0
     }
     for node in recipe_graph:
         predecessors = recipe_graph.predecessors(node)

--- a/src/cascade/input_data/configuration/construct_mortality.py
+++ b/src/cascade/input_data/configuration/construct_mortality.py
@@ -5,8 +5,10 @@ from cascade.input_data.configuration.construct_country import (
     convert_gbd_ids_to_dismod_values
 )
 from cascade.input_data.db.csmr import get_csmr_data, get_csmr_location
+from cascade.input_data.db.data_iterator import grouped_by_count
 from cascade.input_data.db.locations import location_hierarchy, get_descendants
 from cascade.input_data.db.mortality import get_frozen_cause_specific_mortality_data
+from cascade.runner.application_config import application_config
 
 CODELOG, MATHLOG = getLoggers(__name__)
 
@@ -15,22 +17,31 @@ def get_raw_csmr(execution_context, data_access,
                  included_locations, age_spans):
     """Gets CSMR that has age_lower, age_upper, but no further processing."""
     assert isinstance(age_spans, pd.DataFrame)
+    parameters = application_config()["NonModel"]
 
     if data_access.tier == 3:
         CODELOG.debug(f"Getting CSMR from tier 3")
         raw_csmr = get_frozen_cause_specific_mortality_data(
             execution_context, data_access.model_version_id)
     else:
-        if included_locations is not None and len(included_locations) < 10:
+        small_number_locations = parameters.getint("small-location-count")
+        if included_locations is not None and len(included_locations) < small_number_locations:
             CODELOG.debug(f"CSMR retrieval for {included_locations}.")
-            raw_csmr = get_csmr_location(
-                execution_context,
-                included_locations,
-                data_access.add_csmr_cause,
-                data_access.cod_version,
-                data_access.gbd_round_id,
-                data_access.decomp_step,
-            )
+            # Call db_queries multiple times because it uses the SQL in set()
+            # syntax, which fails when the set is large.
+            locations_per_query = parameters.getint("locations-per-query")
+            multiple_csmr = list()
+            for location_bunch in grouped_by_count(included_locations, locations_per_query):
+                piece = get_csmr_location(
+                    execution_context,
+                    location_bunch,
+                    data_access.add_csmr_cause,
+                    data_access.cod_version,
+                    data_access.gbd_round_id,
+                    data_access.decomp_step,
+                )
+                multiple_csmr.append(piece)
+            raw_csmr = pd.concat(multiple_csmr, axis=0, ignore_index=True, sort=False)
         else:
             CODELOG.debug(
                 f"CSMR retrieval for location_set_id {data_access.location_set_id}.")

--- a/src/cascade/input_data/configuration/construct_mortality.py
+++ b/src/cascade/input_data/configuration/construct_mortality.py
@@ -11,7 +11,7 @@ from cascade.input_data.db.mortality import get_frozen_cause_specific_mortality_
 CODELOG, MATHLOG = getLoggers(__name__)
 
 
-def get_raw_csmr(execution_context, data_access, parent_id, age_spans):
+def get_raw_csmr(execution_context, data_access, location_set_id, age_spans):
     """Gets CSMR that has age_lower, age_upper, but no further processing."""
     assert isinstance(age_spans, pd.DataFrame)
 
@@ -21,10 +21,9 @@ def get_raw_csmr(execution_context, data_access, parent_id, age_spans):
             execution_context, data_access.model_version_id)
     else:
         CODELOG.debug(f"Getting CSMR directly")
-        location_and_children = location_and_children_from_settings(data_access, parent_id)
         raw_csmr = get_csmr_data(
             execution_context,
-            location_and_children,
+            location_set_id,
             data_access.add_csmr_cause,
             data_access.cod_version,
             data_access.gbd_round_id,

--- a/src/cascade/input_data/configuration/raw_input.py
+++ b/src/cascade/input_data/configuration/raw_input.py
@@ -10,6 +10,7 @@ CODELOG, MATHLOG = getLoggers(__name__)
 EXPECTED_TYPES = dict(
     age_specific_death_rate=[
         ('location', dtype('int64')),
+        ('sex_id', dtype('int64')),
         ('age_lower', dtype('float64')),
         ('age_upper', dtype('float64')),
         ('time_lower', dtype('float64')),

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -86,7 +86,7 @@ def asdr_as_fit_input(location_set_version_id, sexes, gbd_round_id, decomp_step,
     Args:
         location_set_version_id (int): Location set version for which
             to retrieve the data. This is all locations.
-        sexes (int): 1, 2, 3, or 4. Sex_id.
+        sexes (List[int]): 1, 2, 3, or 4. Sex_id.
         gbd_round_id (int): GBD round identifies consistent data sets.
         ages_df (pd.DataFrame): Age_id to age mapping.
         with_hiv (bool): whether to include HIV deaths in mortality.
@@ -94,7 +94,7 @@ def asdr_as_fit_input(location_set_version_id, sexes, gbd_round_id, decomp_step,
     Returns:
         pd.DataFrame: Columns are ``integrand``, ``hold_out``, ``density``,
         ``eta``, ``nu``, ``time_lower``, ``time_upper``, ``age_lower``,
-        ``age_upper``, and ``location``.
+        ``age_upper``, and ``location``, ``sex_id``.
     """
 
     asdr = get_asdr_global(gbd_round_id, decomp_step, location_set_version_id, with_hiv)
@@ -121,7 +121,7 @@ def asdr_by_sex(asdr, ages, sexes):
         nu=nan,
     )
     trimmed = rest.drop(columns=["age_group_id", "upper", "lower"])
-    return trimmed.query("sex_id in @sexes").drop(columns=["sex_id"])
+    return trimmed.query("sex_id in @sexes")
 
 
 def _upload_asdr_data_to_tier_3(gbd_round_id, cursor, model_version_id, asdr_data):

--- a/src/cascade/input_data/db/asdr.py
+++ b/src/cascade/input_data/db/asdr.py
@@ -55,6 +55,7 @@ def get_asdr_global(gbd_round_id, decomp_step, location_set_version_id, with_hiv
     """
     return get_asdr_formatted(dict(
         location_set_version_id=location_set_version_id,
+        location_id="all",
         year_id=-1,
         gbd_round_id=gbd_round_id,
         decomp_step=decomp_step,

--- a/src/cascade/input_data/db/configuration.py
+++ b/src/cascade/input_data/db/configuration.py
@@ -98,6 +98,9 @@ def json_settings_to_frozen_settings(raw_settings, mvid=None):
     Args:
         raw_settings (dict): Dict of dicts, representing the JSON settings.
         mvid (int,optional): Model version ID to put into the settings.
+
+    Returns:
+        Configuration: Represents validated settings.
     """
     if "model_version_id" not in raw_settings["model"] or not raw_settings["model"]["model_version_id"]:
         raw_settings["model"]["model_version_id"] = mvid

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -72,7 +72,7 @@ def get_csmr_data(
 def get_csmr_location(
         execution_context, location_id, cause_id, cod_version, gbd_round_id, decomp_step
 ):
-    """Retrieve CSMR just for one location."""
+    """Retrieve CSMR for one location or for a list of locations."""
     return get_csmr_base(
         execution_context,
         cause_id,

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -56,15 +56,39 @@ def _gbd_process_version_id_from_cod_version(cod_version):
 
 
 def get_csmr_data(
-        execution_context, location_set_id, cause_id, cod_version, gbd_round_id, decomp_step):
+        execution_context, location_set_id, cause_id, cod_version, gbd_round_id, decomp_step
+):
+    return get_csmr_base(
+        execution_context,
+        cause_id,
+        cod_version,
+        gbd_round_id,
+        decomp_step,
+        dict(location_set_id=location_set_id, location_id="all"),
+    )
+
+
+def get_csmr_location(
+        execution_context, location_id, cause_id, cod_version, gbd_round_id, decomp_step
+):
+    return get_csmr_base(
+        execution_context,
+        cause_id,
+        cod_version,
+        gbd_round_id,
+        decomp_step,
+        dict(location_id=location_id),
+    )
+
+
+def get_csmr_base(
+        execution_context, cause_id, cod_version, gbd_round_id, decomp_step, extra_args):
     keep_cols = ["year_id", "location_id", "sex_id", "age_group_id", "val", "lower", "upper"]
 
     process_version_id = _gbd_process_version_id_from_cod_version(cod_version)
 
     csmr = db_queries.get_outputs(
         topic="cause",
-        location_id="all",
-        location_set_id=location_set_id,
         cause_id=cause_id,
         metric_id=METRIC_IDS["per_capita_rate"],
         year_id="all",
@@ -74,10 +98,10 @@ def get_csmr_data(
         gbd_round_id=gbd_round_id,
         decomp_step=decomp_step,
         process_version_id=process_version_id,
+        **extra_args,
     )[keep_cols]
 
     csmr = csmr[csmr["val"].notnull()]
-
     csmr = csmr.rename(columns={"val": "mean"})
 
     return csmr

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -58,6 +58,7 @@ def _gbd_process_version_id_from_cod_version(cod_version):
 def get_csmr_data(
         execution_context, location_set_id, cause_id, cod_version, gbd_round_id, decomp_step
 ):
+    """Retrieve CSMR for all locations in a location set."""
     return get_csmr_base(
         execution_context,
         cause_id,
@@ -71,6 +72,7 @@ def get_csmr_data(
 def get_csmr_location(
         execution_context, location_id, cause_id, cod_version, gbd_round_id, decomp_step
 ):
+    """Retrieve CSMR just for one location."""
     return get_csmr_base(
         execution_context,
         cause_id,
@@ -82,7 +84,9 @@ def get_csmr_location(
 
 
 def get_csmr_base(
-        execution_context, cause_id, cod_version, gbd_round_id, decomp_step, extra_args):
+        execution_context, cause_id, cod_version, gbd_round_id, decomp_step, extra_args
+):
+    """Gets CSMR with minor formatting, limiting it to desired columns."""
     keep_cols = ["year_id", "location_id", "sex_id", "age_group_id", "val", "lower", "upper"]
 
     process_version_id = _gbd_process_version_id_from_cod_version(cod_version)

--- a/src/cascade/input_data/db/csmr.py
+++ b/src/cascade/input_data/db/csmr.py
@@ -56,14 +56,15 @@ def _gbd_process_version_id_from_cod_version(cod_version):
 
 
 def get_csmr_data(
-        execution_context, location_and_children, cause_id, cod_version, gbd_round_id, decomp_step):
+        execution_context, location_set_id, cause_id, cod_version, gbd_round_id, decomp_step):
     keep_cols = ["year_id", "location_id", "sex_id", "age_group_id", "val", "lower", "upper"]
 
     process_version_id = _gbd_process_version_id_from_cod_version(cod_version)
 
     csmr = db_queries.get_outputs(
         topic="cause",
-        location_id=location_and_children,
+        location_id="all",
+        location_set_id=location_set_id,
         cause_id=cause_id,
         metric_id=METRIC_IDS["per_capita_rate"],
         year_id="all",

--- a/src/cascade/input_data/db/data_iterator.py
+++ b/src/cascade/input_data/db/data_iterator.py
@@ -1,0 +1,3 @@
+def grouped_by_count(identifiers, count):
+    for i in range((len(identifiers) - 1) // count + 1):
+        yield identifiers[i * count:(i + 1) * count]

--- a/src/cascade/testing_utilities/fake_data.py
+++ b/src/cascade/testing_utilities/fake_data.py
@@ -106,12 +106,19 @@ def retrieve_fake_data(execution_context, local_settings, covariate_data_spec, r
             data.ages_df, data.years_df, local_settings.sexes,
             local_settings.children, include_birth_prevalence)
 
+    locations_for_asdr = [local_settings.parent_location_id] + children
     all_ages = age_spans.get_age_spans()
     data.cause_specific_mortality_rate = get_raw_csmr(
-        execution_context, local_settings.data_access, children, all_ages)
+        execution_context, local_settings.data_access, locations_for_asdr, all_ages)
     data.age_specific_death_rate = asdr_as_fit_input(
-        local_settings.parent_location_id, children, local_settings.sexes,
-        data_access.gbd_round_id, data_access.decomp_step, data.ages_df, with_hiv=data_access.with_hiv)
+        data_access.location_set_version_id,
+        locations_for_asdr,
+        local_settings.sexes,
+        data_access.gbd_round_id,
+        data_access.decomp_step,
+        data.ages_df,
+        with_hiv=data_access.with_hiv
+    )
     data.study_id_to_name, data.country_id_to_name = find_covariate_names(
         execution_context, covariate_data_spec)
     assign_epiviz_covariate_names(

--- a/src/cascade/testing_utilities/fake_data.py
+++ b/src/cascade/testing_utilities/fake_data.py
@@ -7,6 +7,7 @@ from numpy.random import RandomState
 from cascade.core import getLoggers
 from cascade.core.db import age_spans
 from cascade.core.db import db_queries
+from cascade.executor.covariate_data import assign_epiviz_covariate_names
 from cascade.executor.covariate_data import find_covariate_names
 from cascade.input_data.configuration.construct_mortality import get_raw_csmr
 from cascade.input_data.configuration.raw_input import validate_input_data_types
@@ -107,12 +108,15 @@ def retrieve_fake_data(execution_context, local_settings, covariate_data_spec, r
 
     all_ages = age_spans.get_age_spans()
     data.cause_specific_mortality_rate = get_raw_csmr(
-        execution_context, local_settings.data_access, local_settings.parent_location_id, all_ages)
+        execution_context, local_settings.data_access, children, all_ages)
     data.age_specific_death_rate = asdr_as_fit_input(
-        local_settings.parent_location_id, local_settings.sexes,
+        local_settings.parent_location_id, children, local_settings.sexes,
         data_access.gbd_round_id, data_access.decomp_step, data.ages_df, with_hiv=data_access.with_hiv)
     data.study_id_to_name, data.country_id_to_name = find_covariate_names(
         execution_context, covariate_data_spec)
+    assign_epiviz_covariate_names(
+        data.study_id_to_name, data.country_id_to_name, covariate_data_spec
+    )
 
     # These are the draws as output of the parent location.
     data.draws = None

--- a/tests/executor/test_construct_model.py
+++ b/tests/executor/test_construct_model.py
@@ -29,6 +29,7 @@ from cascade.testing_utilities.fake_data import retrieve_fake_data
 
 @pytest.fixture
 def base_settings():
+    """These are default initial values for the random generation of settings."""
     return """
     iota = True
     rho = False
@@ -118,7 +119,7 @@ def make_a_db(local_settings, locations, filename):
     )
     ec = make_execution_context()
     input_data = retrieve_fake_data(ec, local_settings, covariate_data_spec)
-    modified_data = modify_input_data(input_data, local_settings, covariate_data_spec)
+    modified_data = modify_input_data(input_data, local_settings)
     model = construct_model(modified_data, local_settings, covariate_multipliers, covariate_data_spec)
     session = Session(location_hierarchy_to_dataframe(locations),
                       parent_location=1, filename=filename)
@@ -127,6 +128,7 @@ def make_a_db(local_settings, locations, filename):
 
 
 def construct_model_fair(ec, filename, rng_state):
+    """Thread test from making settings to running the first init."""
     rng = RandomState()
     rng.set_state(rng_state)
 
@@ -147,6 +149,7 @@ def construct_model_fair(ec, filename, rng_state):
         pickle.dump(rng_state, Path("fail_state.pkl").open("wb"))
         raise
 
+    # These check that covariate data was assigned.
     for dismod_cov_idx in range(len(covariate_data_spec)):
         name, ref, max_diff, values = pull_covariate(filename, dismod_cov_idx)
         if name == "s_one":
@@ -179,6 +182,7 @@ def change_setting_in_local_settings(settings, name, value):
     setattr(obj, members[-1], value)
 
 
+@pytest.mark.skip("Update for new way to make a db.")
 @pytest.mark.parametrize("draw", list(range(10)))
 def test_construct_model_fair(ihme, tmp_path, draw):
     lose_file = True

--- a/tests/executor/test_construct_model.py
+++ b/tests/executor/test_construct_model.py
@@ -29,7 +29,9 @@ from cascade.testing_utilities.fake_data import retrieve_fake_data
 
 @pytest.fixture
 def base_settings():
-    """These are default initial values for the random generation of settings."""
+    """These are default initial values for the random generation of settings.
+    Look at create_settings to see what each of these lines sets.
+    """
     return """
     iota = True
     rho = False
@@ -193,6 +195,7 @@ def test_construct_model_fair(ihme, tmp_path, draw):
 
 
 def test_same_settings(ihme, tmp_path, base_settings, reference_db):
+    """Shows that if we don't change settings, the tester doesn't see a change."""
     filename = tmp_path / "single_settings.db"
     local_settings, locations = make_local_settings(base_settings)
     make_a_db(local_settings, locations, filename)
@@ -224,6 +227,7 @@ def test_same_settings(ihme, tmp_path, base_settings, reference_db):
     ("settings.tolerance.random", 1.23, "tolerance_random"),
 ])
 def test_option_settings(ihme, tmp_path, base_settings, reference_db, setstr, val, opt):
+    """Proves that each of these EpiViz settings makes it all the way to the db file."""
     filename = tmp_path / "single_settings.db"
     local_settings, locations = make_local_settings(base_settings)
     change_setting_in_local_settings(local_settings, setstr, val)

--- a/tests/executor/test_construct_model.py
+++ b/tests/executor/test_construct_model.py
@@ -136,7 +136,7 @@ def construct_model_fair(ec, filename, rng_state):
         local_settings.settings.country_covariate, local_settings.settings.study_covariate
     )
     input_data = retrieve_fake_data(ec, local_settings, covariate_data_spec)
-    modified_data = modify_input_data(input_data, local_settings, covariate_data_spec)
+    modified_data = modify_input_data(input_data, local_settings)
     model = construct_model(modified_data, local_settings, covariate_multipliers, covariate_data_spec)
     assert len(model.rate.keys()) > 0
     session = Session(location_hierarchy_to_dataframe(locations),

--- a/tests/executor/test_estimate_locations.py
+++ b/tests/executor/test_estimate_locations.py
@@ -1,4 +1,3 @@
-import pickle
 import shutil
 from os import walk
 from pathlib import Path
@@ -11,7 +10,6 @@ from cascade.executor.create_settings import SettingsChoices, create_settings
 from cascade.executor.dismodel_main import DismodAT
 from cascade.executor.execution_context import make_execution_context
 from cascade.input_data.db.locations import location_hierarchy
-from cascade.input_data.db.configuration import json_settings_to_frozen_settings
 
 
 @pytest.mark.parametrize("meid,mvid", [
@@ -74,48 +72,43 @@ def globaldir(request, tmp_path):
     minutes, and this sets us up to test any part of the hierarchy.
     Use ``pytest --clear-cache`` to erase this entry and re-download.
     """
-    base_path = request.config.cache.get("run_global/globaldir", None)
-    if isinstance(base_path, str):
-        base_path = Path(base_path)
-    if base_path is None or not (base_path / "globaldata.hdf").exists():
+    def by_draw(draw):
         ec = make_execution_context()
-        draw = 12
         rng = RandomState(524287 + 131071 * draw)
         locs = location_hierarchy(6, 429)
 
         choices = SettingsChoices(rng, None)
         settings = create_settings(choices, locs)
 
-        app = DismodAT(locs, settings, ec)
-        # skip-cache says to use Tier 2 data.
-        arg_list = [
-            "--no-upload", "--db-only", "-v",
-            "--base-directory", str(tmp_path),
-            "--location", "0", "--skip-cache",
-            "--recipe", "bundle_setup",  # We are asking for one particular recipe.
-        ]
-        entry(app, arg_list)
-        meid = "23514"
-        mvid = "267890"
-        loc = "0"
-        sex = "both"
-        base = tmp_path / meid / mvid / "0" / loc / sex
-        global_data = base / "globaldata.hdf"
-        assert global_data.exists()
-        # Convert settings to a dict b/c they don't serialize perfectly.
-        pickle.dump(settings.to_dict(), (base / "settings.pickle").open("wb"))
-        request.config.cache.set("run_global/globaldir", str(base))
-    else:
-        # Why copy settings? Because they have specific locations and options.
-        raw_settings = pickle.load((base_path / "settings.pickle").open("rb"))
-        # This is the step that deserializes and validates, the important part.
-        settings = json_settings_to_frozen_settings(raw_settings)
-    return settings, base_path
+        base_path = request.config.cache.get(f"run_global/globaldir{draw}", None)
+        if isinstance(base_path, str):
+            base_path = Path(base_path)
+        if base_path is None or not (base_path / "globaldata.hdf").exists():
+            app = DismodAT(locs, settings, ec)
+            # skip-cache says to use Tier 2 data.
+            arg_list = [
+                "--no-upload", "--db-only", "-v",
+                "--base-directory", str(tmp_path),
+                "--location", "0", "--skip-cache",
+                "--recipe", "bundle_setup",  # We are asking for one particular recipe.
+            ]
+            entry(app, arg_list)
+            meid = "23514"
+            mvid = "267890"
+            loc = "0"
+            sex = "both"
+            base = tmp_path / meid / mvid / "0" / loc / sex
+            global_data = base / "globaldata.hdf"
+            assert global_data.exists()
+            # Convert settings to a dict b/c they don't serialize perfectly.
+            request.config.cache.set(f"run_global/globaldir{draw}", str(base))
+        return settings, base_path
+    return by_draw
 
 
 @pytest.mark.parametrize("draw", list(range(1)))
 def test_run_global(ihme, draw, tmp_path, globaldir):
-    settings, global_data = globaldir
+    settings, global_data = globaldir(draw)
     ec = make_execution_context()
     locs = location_hierarchy(6, 429)
     app = DismodAT(locs, settings, ec)

--- a/tests/executor/test_estimate_locations.py
+++ b/tests/executor/test_estimate_locations.py
@@ -100,8 +100,8 @@ def globaldir(request, tmp_path):
             base = tmp_path / meid / mvid / "0" / loc / sex
             global_data = base / "globaldata.hdf"
             assert global_data.exists()
-            # Convert settings to a dict b/c they don't serialize perfectly.
             request.config.cache.set(f"run_global/globaldir{draw}", str(base))
+            base_path = base
         return settings, base_path
     return by_draw
 

--- a/tests/executor/test_estimate_locations.py
+++ b/tests/executor/test_estimate_locations.py
@@ -1,16 +1,13 @@
+from os import walk
+
 import pytest
 from gridengineapp import entry
 from numpy.random import RandomState
 
-from cascade.executor.construct_model import construct_model
-from cascade.executor.covariate_description import create_covariate_specifications
-from cascade.executor.create_settings import create_local_settings
+from cascade.executor.create_settings import SettingsChoices, create_settings
 from cascade.executor.dismodel_main import DismodAT
 from cascade.executor.execution_context import make_execution_context
-from cascade.executor.priors_from_draws import set_priors_from_parent_draws
-from cascade.input_data.configuration.raw_input import validate_input_data_types
 from cascade.input_data.db.locations import location_hierarchy
-from cascade.testing_utilities.fake_data import retrieve_fake_data
 
 
 @pytest.mark.parametrize("meid,mvid", [
@@ -32,20 +29,33 @@ def test_with_known_id(ihme, meid, mvid, tmp_path):
     entry(app, args)
 
 
-@pytest.mark.skip("for the main rewrite")
-@pytest.mark.parametrize("draw", list(range(10)))
-def test_retrieve_data(ihme, draw):
+@pytest.mark.parametrize("draw", list(range(1)))
+def test_retrieve_data(ihme, draw, tmp_path):
     ec = make_execution_context()
     rng = RandomState(524287 + 131071 * draw)
     locs = location_hierarchy(5, 429)
-    local_settings, locations = create_local_settings(rng, locations=locs)
-    covariate_multipliers, covariate_data_spec = create_covariate_specifications(
-        local_settings.settings.study_covariate, local_settings.settings.country_covariate
-    )
-    # Here, we create a fake input data so that there is a bundle and study covariates.
-    input_data = retrieve_fake_data(ec, local_settings, covariate_data_spec)
-    columns_wrong = validate_input_data_types(input_data)
-    assert not columns_wrong, f"validation failed {columns_wrong}"
-    modified_data = modify_input_data(input_data, local_settings, covariate_data_spec)
-    model = construct_model(modified_data, local_settings, covariate_multipliers, covariate_data_spec)
-    set_priors_from_parent_draws(model, input_data.draws)
+
+    choices = SettingsChoices(rng, None)
+    settings = create_settings(choices, locs)
+
+    app = DismodAT(locs, settings, ec)
+    arg_list = [
+        "--no-upload", "--db-only",
+        "--base-directory", str(tmp_path),
+        "--location", "0",
+        "--recipe", "bundle_setup",  # We are asking for one particular recipe.
+    ]
+    entry(app, arg_list)
+
+    for dirpath, dirnames, filenames in walk(tmp_path):
+        if filenames:
+            print(f"{dirpath}:")
+            print(f"\t{filenames}")
+
+    meid = "23514"
+    mvid = "267890"
+    loc = "0"
+    sex = "both"
+    base = tmp_path / meid / mvid / "0" / loc / sex
+    assert (base / "globaldata.hdf").exists()
+    assert len(list(base.glob("globalvars*"))) > 0

--- a/tests/executor/test_job_definitions.py
+++ b/tests/executor/test_job_definitions.py
@@ -48,7 +48,8 @@ def test_prepare_data(context):
     recipe_id = RecipeIdentifier(21, "bundle_setup", "both")
     local_settings = SimpleNamespace()
     local_settings.parent_location_id = 22
-    prepare = GlobalPrepareData(recipe_id, local_settings, ec)
+    included_locations = None
+    prepare = GlobalPrepareData(recipe_id, local_settings, included_locations, ec)
     assert not prepare.done()
     prepare.mock_run()
     assert prepare.done()
@@ -59,7 +60,8 @@ def test_global_estimate(context):
     recipe_id = RecipeIdentifier(1, "bundle_setup", "both")
     local_settings = SimpleNamespace()
     local_settings.parent_location_id = 1
-    prepare = GlobalPrepareData(recipe_id, local_settings, ec)
+    included_locations = None
+    prepare = GlobalPrepareData(recipe_id, local_settings, included_locations, ec)
     global_recipe = RecipeIdentifier(1, "estimate_location", "both")
     neighbors = dict(
         predecessors=[recipe_id],

--- a/tests/input_data/configuration/test_construct_mortality.py
+++ b/tests/input_data/configuration/test_construct_mortality.py
@@ -1,10 +1,14 @@
 from types import SimpleNamespace
 from cascade.input_data.configuration.construct_mortality import (
-    get_raw_csmr, normalize_csmr
+    normalize_csmr
 )
+from cascade.input_data.db.csmr import get_csmr_location
 import pytest
 from cascade.executor.execution_context import make_execution_context
 from cascade.core.db import age_spans
+from cascade.input_data.configuration.construct_country import (
+    convert_gbd_ids_to_dismod_values
+)
 
 
 @pytest.mark.parametrize("location_id,cause_id", [
@@ -16,12 +20,13 @@ def test_live_csmr(ihme, location_id, cause_id):
     data_access = SimpleNamespace()
     data_access.tier = 2
     data_access.add_csmr_cause = cause_id
-    data_access.cod_version = 90
-    data_access.gbd_round_id = 6
-    data_access.decomp_step = "step1"
+    cod_version = 90
+    gbd_round_id = 6
+    decomp_step = "step1"
     data_access.location_set_version_id = 429
     ages = age_spans.get_age_spans()
-    raw = get_raw_csmr(ec, data_access, location_id, ages)
+    raw_csmr = get_csmr_location(ec, location_id, cause_id, cod_version, gbd_round_id, decomp_step)
+    raw = convert_gbd_ids_to_dismod_values(raw_csmr, ages)
     normed = normalize_csmr(raw, [1, 2])
     assert not set(normed.sex_id.unique().tolist()) - {1, 2}
     expected_cols = {

--- a/tests/input_data/db/test_data_iterator.py
+++ b/tests/input_data/db/test_data_iterator.py
@@ -1,0 +1,26 @@
+import pytest
+
+from cascade.input_data.db.data_iterator import grouped_by_count
+
+
+@pytest.mark.parametrize("in_string,count", [
+    (list(range(11)), 5),
+    (list(range(10)), 5),
+    (list(range(9)), 5),
+    (list(), 5),
+    ([chr(x + ord("a")) for x in range(23)], 7),
+])
+def test_grouped_by_count_happy(in_string, count):
+    result = list()
+    total = set()
+    under = 0
+    for group in grouped_by_count(in_string, count):
+        result.extend(group)
+        total |= set(group)
+        assert len(group) <= count
+        assert len(group) > 0
+        if len(group) < count:
+            under += 1
+    assert len(total) == len(result)
+    assert len(total) == len(in_string)
+    assert under <= 1

--- a/tests/runner/test_run_target.py
+++ b/tests/runner/test_run_target.py
@@ -196,17 +196,6 @@ def test_global_recipe_most_detailed(locations, basic_settings, build_args):
     assert len(global_graph) == setup + both + other
 
 
-def test_global_recipe_skip_cache(locations, basic_settings, build_args):
-    build_args.skip_cache = True
-    global_graph = global_recipe_graph(locations, basic_settings, build_args)
-    location_height = nx.dag_longest_path_length(locations)
-    assert nx.dag_longest_path_length(global_graph) == location_height
-    both = sum(3**n for n in range(4))
-    split = int(basic_settings.model.split_sex)
-    other = sum(3**n for n in range(split, 4))
-    assert len(global_graph) == both + other
-
-
 def test_drill_recipe_graph(locations, basic_settings, build_args):
     basic_settings.model.drill_location_start = 0
     basic_settings.model.drill_location_end = 9

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ log_level = debug
 # numpy.dtype = float size change, noticed by Cython, should ignore.
 # can't resolve = library using dynamic loading, but it works fine.
 # sqlalchemy deprecation = an argument from sqlalchemy we can't control
+# Pandas deprecated item() and it's not in our code but in dependencies.
 filterwarnings =
     error::Warning
     ignore:invalid escape sequence:DeprecationWarning
@@ -16,6 +17,7 @@ filterwarnings =
     ignore:numpy.dtype size changed
     ignore:can't resolve package from __spec__:ImportWarning
     ignore: The create_engine.convert_unicode
+    ignore:`item` has been deprecated
 [testenv]
 extras = testing
 commands = py.test


### PR DESCRIPTION
Constructs jobs for
 - download of initial data
 - fit fixed

Both run, and they use the DismodObjects api, so that they will work the way Greg and Brad want, from a db_file that doesn't get deleted. This also updates other unit tests to work through the CascadeApp, so that they depend less on internal choices and are more of a thread testing approach.