### PR TITLE
Switched to using MSCM singularity

### DIFF
--- a/scripts/dmdismod
+++ b/scripts/dmdismod
@@ -1,9 +1,10 @@
 #!/bin/bash
-SINGULARITY=/ihme/singularity-images/dismod/current.img
+SINGULARITY=/ihme/singularity-images/mscm/current.img
 INSTALLED_DISMOD=$(which dismod_at 2>/dev/null)
 if [ -e "${SINGULARITY}" ]
 then
-    exec singularity exec "${SINGULARITY}" /home/root/prefix/dismod_at/bin/dismod_at $*
+    export LD_LIBRARY_PATH="/home/prefix/dismod_at.release/lib64:${LD_LIBRARY_PATH}"
+    exec singularity exec "${SINGULARITY}" /home/prefix/dismod_at/bin/dismod_at $*
 elif [ -x "${INSTALLED_DISMOD}" ]
 then
     dismod_at $*
@@ -16,5 +17,5 @@ else
     else
         INTERACTIVE=""
     fi
-    exec docker run $INTERACTIVE --mount type=bind,source=${TARGET_DIR},target=/app reg.ihme.washington.edu/dismod/dismod_at /home/root/prefix/dismod_at/bin/dismod_at /app/$TARGET_DB $*
+    exec docker run $INTERACTIVE --mount type=bind,source=${TARGET_DIR},target=/app reg.ihme.washington.edu/mscm/dismod_at /home/prefix/dismod_at/bin/dismod_at /app/$TARGET_DB $*
 fi

--- a/scripts/dmdismodpy
+++ b/scripts/dmdismodpy
@@ -1,9 +1,10 @@
 #!/bin/bash
-SINGULARITY=/ihme/singularity-images/dismod/current.img
+SINGULARITY=/ihme/singularity-images/mscm/current.img
 if [ -e "${SINGULARITY}" ]
 then
-    exec singularity exec "${SINGULARITY}" /home/root/prefix/dismod_at/bin/dismodat.py $*
+    export LD_LIBRARY_PATH="/home/prefix/dismod_at.release/lib64:${LD_LIBRARY_PATH}"
+    exec singularity exec "${SINGULARITY}" /home/prefix/dismod_at/bin/dismodat.py $*
 else
     CURDIR=$(pwd)
-    exec docker run -it --mount type=bind,source=${CURDIR},target=/app reg.ihme.washington.edu/dismod/dismod_at /home/root/prefix/dismod_at/bin/dismodat.py $*
+    exec docker run -it --mount type=bind,source=${CURDIR},target=/app reg.ihme.washington.edu/mscm/dismod_at /home/prefix/dismod_at/bin/dismodat.py $*
 fi

--- a/src/cascade/core/subprocess_utils.py
+++ b/src/cascade/core/subprocess_utils.py
@@ -1,4 +1,3 @@
-import os
 import asyncio
 import re
 import subprocess
@@ -117,17 +116,14 @@ def processor_type():
 @lru_cache(maxsize=1)
 def this_machine_has_newer_time_command():
     """Check whether the timer could work. Do this once.
-    Some systems have older copies of /usr/bin/time that don't have -v.
-    On some systems (e.g., OS X) the newer command is gtime."""
-    time_cmds = os.popen('which time').readlines() + os.popen('which gtime').readlines()
-    for timer in time_cmds:
-        timer = Path(timer.strip())
-        if timer.exists():
-            time_line = [str(timer), "-vo"]
-            result = run(time_line + ["/dev/null", "/bin/ls"],
-                         stdout=DEVNULL, stderr=DEVNULL)
-            if result.returncode == 0:
-                return time_line
+    Some systems have older copies of /usr/bin/time that don't have -v."""
+    timer = Path("/usr/bin/time")
+    time_line = [str(timer), "-vo"]
+    if timer.exists():
+        result = run(time_line + ["/dev/null", "/bin/ls"],
+                     stdout=DEVNULL, stderr=DEVNULL)
+        if result.returncode == 0:
+            return time_line
     return None
 
 

--- a/tests/core/test_subprocess_utils.py
+++ b/tests/core/test_subprocess_utils.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from subprocess import run
 
@@ -41,8 +40,7 @@ def test_run_with_logging__bad_executable():
 def test_add_gross_timing():
     command = "ls ."
     command, tmp_file = add_gross_timing(command)
-    time_cmds = os.popen('which time').readlines() + os.popen('which gtime').readlines()
-    assert any([command == [_.strip()] + ["-vo", str(tmp_file), "ls", "."] for _ in time_cmds])
+    assert command == ["/usr/bin/time", "-vo", str(tmp_file), "ls", "."]
 
 
 def test_try_gross_timing():


### PR DESCRIPTION
- Switched to using the singularity image under the reg.ihme.uw.edu/mscm docker registry. Needed to export the `LD_LIBRARY_PATH` before `exec singularity` call because it masks only that path and the solutions suggested in https://github.com/sylabs/singularity/issues/411 did not work
- Reverted commit from @gma-uw for use on the IHME cluster / travis (currently works on Mac systems with `gtime` installed but not on linux systems)