### PR TITLE
Print full file path

### DIFF
--- a/src/cascade/executor/job_definitions.py
+++ b/src/cascade/executor/job_definitions.py
@@ -37,7 +37,7 @@ def save_global_data_to_hdf(path, global_data):
     else:
         CODELOG.info(f"All global data is dataframes.")
 
-    CODELOG.info(f"HDFStore path {path}")
+    CODELOG.info(f"HDFStore path {path.absolute()}")
     with closing(pd.HDFStore(str(path), "w", complevel=9, complib="zlib")) as store:
         for name, df in dataframes.items():
             store.put(name, df, format="fixed", columns=True, dropna=False)

--- a/src/cascade/input_data/configuration/construct_bundle.py
+++ b/src/cascade/input_data/configuration/construct_bundle.py
@@ -198,4 +198,4 @@ def dataframe_from_disk(path):
     elif path.endswith(".csv"):
         return pd.read_csv(path)
     else:
-        raise ValueError(f"Unknown file format for bundle: {path}")
+        raise ValueError(f"Unknown file format for bundle: {path.absolute()}")

--- a/src/cascade/input_data/configuration/construct_country.py
+++ b/src/cascade/input_data/configuration/construct_country.py
@@ -246,23 +246,22 @@ def compute_interpolated_covariate_values_by_sex(
         # covariate is by_age and "by_time"
         if covar_at_dims.age_1d and covar_at_dims.time_1d:
 
-            covariate_sex = griddata((covariates_sex["avg_age"], covariates_sex["avg_time"]),
-                                     covariates_sex["mean_value"],
-                                     (meas_sex_new_index["avg_age"], meas_sex_new_index["avg_time"]))
+            covariate_sex = griddata((covariates_sex["avg_age"].values, covariates_sex["avg_time"].values),
+                                     covariates_sex["mean_value"].values,
+                                     (meas_sex_new_index["avg_age"].values, meas_sex_new_index["avg_time"].values))
 
         # covariate is "by_time", but not by_age
         elif not covar_at_dims.age_1d and covar_at_dims.time_1d:
-
-            covariate_sex = griddata((covariates_sex["avg_time"],),
-                                     covariates_sex["mean_value"],
-                                     (meas_sex_new_index["avg_time"],))
+            covariate_sex = griddata((covariates_sex["avg_time"].values,),
+                                     covariates_sex["mean_value"].values,
+                                     (meas_sex_new_index["avg_time"].values,))
 
         # covariate is by_age, but not "by_time"
         elif covar_at_dims.age_1d and not covar_at_dims.time_1d:
 
-            covariate_sex = griddata((covariates_sex["avg_age"],),
-                                     covariates_sex["mean_value"],
-                                     (meas_sex_new_index["avg_age"],))
+            covariate_sex = griddata((covariates_sex["avg_age"].values,),
+                                     covariates_sex["mean_value"].values,
+                                     (meas_sex_new_index["avg_age"].values,))
         else:
             raise RuntimeError(f"Covariate sex neither by age nor time {covar_at_dims}.")
 


### PR DESCRIPTION
This makes it easier to find the files created by the cascade by printing the full file pathname in the logs.