### PR TITLE
At the top level node, compute_parent_fit_fixed is being called with …

### DIFF
--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -285,7 +285,7 @@ def compute_parent_fit(execution_context, db_path, local_settings, simulate_idx=
             CODELOG.warning(msg)
             try:
                 dismod_objects.sample
-            except: 
+            except Exception:
                 simulate_idx = None
                 CODELOG.error(msg)
 

--- a/src/cascade/executor/estimate_location.py
+++ b/src/cascade/executor/estimate_location.py
@@ -276,6 +276,19 @@ def compute_parent_fit(execution_context, db_path, local_settings, simulate_idx=
     if not local_settings.run.db_only:
         dismod_objects.run_dismod("init")
         command = ["fit", "both"]
+
+        __patch__ = True
+        if __patch__:
+            # GMA -- this is a kluge -- need to clean up all of this dismod call sequencing
+            msg = 'At the top level node, we have no priors (samples) so we should not be '\
+                'calling compute_parent_fit with simulate_idx != None.'
+            CODELOG.warning(msg)
+            try:
+                dismod_objects.sample
+            except: 
+                simulate_idx = None
+                CODELOG.error(msg)
+
         if simulate_idx is not None:
             command += [simulate_idx]
         stdout, stderr, _metrics = dismod_objects.run_dismod(command)


### PR DESCRIPTION
…simulate_idx = None, and the code was setting it to 1. This resulted in a dismod call with arguments fit both 1, which was an error as there are no samples at the top level. I think it may also be an error below the top level, as it would cause dismod to fit the first sample, rather than the raw data, as intended by this function. Again, the entire dismod call sequencing strategy needs to be refactored.