### PR TITLE
DISMODAT-693: Saving uncertainty in the prior

### DIFF
--- a/src/cascade_at/cascade/cascade_stacks.py
+++ b/src/cascade_at/cascade/cascade_stacks.py
@@ -175,7 +175,8 @@ def root_fit(model_version_id: int, location_id: int, sex_id: int,
         both=False,
         predict=True,
         upstream_commands=upstream,
-        save_fit=True
+        save_fit=True,
+        save_prior=True
     )
     tasks.append(t2)
     t3 = Predict(

--- a/src/cascade_at/executor/dismod_db.py
+++ b/src/cascade_at/executor/dismod_db.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from typing import Union, List, Dict, Any, Optional, Tuple
 import os
-import pandas as pd
 import numpy as np
 import pandas as pd
 
@@ -23,6 +22,7 @@ from cascade_at.model.grid_alchemy import Alchemy
 from cascade_at.saver.results_handler import ResultsHandler
 from cascade_at.settings.settings_config import SettingsConfig
 from cascade_at.model.priors import Gaussian, _Prior
+from cascade_at.dismod.api.fill_extract_helpers.posterior_to_prior import format_rate_grid_for_ihme
 
 
 LOG = get_loggers(__name__)
@@ -89,7 +89,7 @@ def fill_database(path: Union[str, Path], settings: SettingsConfig,
                   inputs: MeasurementInputs, alchemy: Alchemy,
                   parent_location_id: int, sex_id: int, child_prior: Dict[str, Dict[str, np.ndarray]],
                   mulcov_prior: Dict[Tuple[str, str, str], _Prior],
-                  options: Dict[str, Any]) -> None:
+                  options: Dict[str, Any]) -> DismodFiller:
     """
     Fill a DisMod database at the specified path with the inputs, model, and settings
     specified, for a specific parent and sex ID, with options to override the priors.
@@ -100,6 +100,7 @@ def fill_database(path: Union[str, Path], settings: SettingsConfig,
         child_prior=child_prior, mulcov_prior=mulcov_prior,
     )
     df.fill_for_parent_child(**options)
+    return df
 
 
 def save_predictions(db_file: Union[str, Path],
@@ -157,6 +158,11 @@ def dismod_db(model_version_id: int, parent_location_id: int, sex_id: int,
         directly on the dismod database
     dm_options
         A dictionary of options to pass to the the dismod option table
+    prior_samples
+        Whether the prior was derived from samples or not
+    prior_mulcov_model_version_id
+        The model version ID to use for pulling covariate multiplier
+        statistics as priors for this fit
     prior_parent
         An optional parent location ID that specifies where to pull the prior
         information from.
@@ -172,7 +178,7 @@ def dismod_db(model_version_id: int, parent_location_id: int, sex_id: int,
     save_fit
         Whether or not to save the fit from this database as the parent fit.
     save_prior
-        Whether or not to save the prior for the children as the prior fit.
+        Whether or not to save the prior for the parent as the parent's prior.
     """
     if test_dir is not None:
         context = Context(model_version_id=model_version_id,
@@ -196,19 +202,8 @@ def dismod_db(model_version_id: int, parent_location_id: int, sex_id: int,
             rates=[r.rate for r in settings.rate],
             samples=prior_samples
         )
-        if save_prior:
-            save_predictions(
-                db_file=prior_db,
-                locations=[parent_location_id], sexes=[sex_id],
-                model_version_id=model_version_id,
-                gbd_round_id=settings.gbd_round_id,
-                out_dir=context.prior_dir
-            )
     else:
         child_prior = None
-        if save_prior:
-            raise DismodDBError("Cannot save the prior because there was no argument"
-                                "passed in for the prior_parent or prior_sex.")
 
     if prior_mulcov_model_version_id is not None:
         LOG.info(f'Passing mulcov prior from model version id = {prior_mulcov_model_version_id}') 
@@ -217,12 +212,24 @@ def dismod_db(model_version_id: int, parent_location_id: int, sex_id: int,
         mulcov_priors = None
 
     if fill:
-        fill_database(
+        filler = fill_database(
             path=db_path, inputs=inputs, alchemy=alchemy, settings=settings,
             parent_location_id=parent_location_id, sex_id=sex_id,
             child_prior=child_prior, options=dm_options,
             mulcov_prior=mulcov_priors,
         )
+        if save_prior:
+            priors_to_save = format_rate_grid_for_ihme(
+                rates=filler.parent_child_model['rate'],
+                gbd_round_id=settings.gbd_round_id,
+                location_id=parent_location_id,
+                sex_id=sex_id
+            )
+            rh = ResultsHandler()
+            rh.save_summary_files(
+                df=priors_to_save, directory=context.prior_dir,
+                model_version_id=model_version_id
+            )
 
     if dm_commands:
         run_dismod_commands(dm_file=str(db_path), commands=dm_commands)

--- a/src/cascade_at/inputs/utilities/gbd_ids.py
+++ b/src/cascade_at/inputs/utilities/gbd_ids.py
@@ -190,3 +190,36 @@ def get_country_level_covariate_ids(country_covariate_id):
     df = df.loc[df.covariate_id.isin(country_covariate_id)].copy()
     cov_dict = df[['covariate_id', 'covariate_name_short']].set_index('covariate_id').to_dict('index')
     return {k: f"c_{v['covariate_name_short']}" for k, v in cov_dict.items()}
+
+
+def format_age_time(df: pd.DataFrame, gbd_round_id: int) -> pd.DataFrame:
+    """
+    Formats age_lower, age_upper, and time_lower and time_upper
+    into the IHME age and time bins.
+
+    Parameters
+    ----------
+    df
+        data frame with age lower and upper or age_group_id AND
+        time lower and upper or year_id
+    gbd_round_id
+        gbd round
+
+    Returns
+    -------
+    data frame with mapped and and time to IHME ages and times
+    """
+    map_age = 'age_group_id' not in df.columns
+    map_year = 'year_id' not in df.columns
+
+    if map_age:
+        age_intervals = make_age_intervals(gbd_round_id=gbd_round_id)
+        df['age_group_id'] = df['age_lower'].apply(
+            lambda x: map_id_from_interval_tree(index=x, tree=age_intervals)
+        )
+    if map_year:
+        time_intervals = make_time_intervals()
+        df['year_id'] = df['time_lower'].apply(
+            lambda x: map_id_from_interval_tree(index=x, tree=time_intervals)
+        )
+    return df

--- a/tests/dismod/api/fill_extract_helpers/test_posterior_to_prior.py
+++ b/tests/dismod/api/fill_extract_helpers/test_posterior_to_prior.py
@@ -7,6 +7,8 @@ from cascade_at.dismod.api.fill_extract_helpers.posterior_to_prior import get_pr
 from cascade_at.model.utilities.integrand_grids import integrand_grids
 from cascade_at.model.grid_alchemy import Alchemy
 from cascade_at.model.utilities.grid_helpers import estimate_grid_from_draws
+from cascade_at.dismod.api.fill_extract_helpers.posterior_to_prior import format_rate_grid_for_ihme
+from cascade_at.dismod.api.dismod_filler import DismodFiller
 
 
 def test_get_prior_avgint_grid():
@@ -97,3 +99,24 @@ def test_apply_min_cv_to_value():
     alchemy.apply_min_cv_to_prior_grid(prior_grid=prior, min_cv=1e6)
     for (a, age), (t, time) in zip(enumerate(prior.ages), enumerate(prior.times)):
         assert prior[age, time].standard_deviation == prior[age, time].mean * 1e6
+
+
+def test_format_rate_grid_for_ihme(mi):
+    settings = load_settings(BASE_CASE)
+    alchemy = Alchemy(settings)
+    d = DismodFiller(
+        path='none',
+        settings_configuration=settings,
+        measurement_inputs=mi,
+        grid_alchemy=alchemy,
+        parent_location_id=70,
+        sex_id=2
+    )
+    grid = format_rate_grid_for_ihme(
+        rates=d.parent_child_model['rate'],
+        gbd_round_id=6,
+        location_id=70,
+        sex_id=2
+    )
+    assert all(grid.columns == ['location_id', 'year_id', 'age_group_id',
+                                'sex_id', 'measure_id', 'mean', 'upper', 'lower'])


### PR DESCRIPTION
This PR will make it so that the prior has mean upper and lower saved, rather than just mean as it is now. In order to do this, I needed to modify the `rvs` function (random variates) for each of the prior distributions (in `priors.py`) so that it censored the distribution rather than just resampling until something fell within bounds. Then I get the upper and lower based on the prior `SmoothGrid`, and save that to the epi database using `ResultsHandler()` in the `dismod_db` executable.

Importantly, this will work the same way for priors starting at the top level of the cascade (global) as it will for going down the cascade where the priors are filled in by the fit from its parent.