### PR TITLE
DISMODAT-700: Age groups > 95 getting cut off

### DIFF
--- a/src/cascade_at/inputs/base_input.py
+++ b/src/cascade_at/inputs/base_input.py
@@ -14,16 +14,21 @@ class BaseInput:
             'name', 'hold_out', 'density', 'eta', 'nu'
         ]
 
-    def convert_to_age_lower_upper(self, df):
+    def convert_to_age_lower_upper(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Converts a data frame that has age_group_id to
         age lower and upper based on age group metadata.
-        :param df: (pd.DataFrame) data frame with column
-            age_group_id
-        :return: (pd.DataFrame)
+        Replaces the age_upper of 125 with 100 for the 95+ age
+        group ID 235.
+
+        Parameters
+        ----------
+        df
+            A data frame that has age group ID
         """
         df.age_group_id = df.age_group_id.astype(int)
         df = df.merge(self.age_group_metadata, on='age_group_id')
+        df.loc[df.age_upper == 125., 'age_upper'] = 100.
         return df
 
     def keep_only_necessary_columns(self, df):


### PR DESCRIPTION
This is a fix for the age groups > 95 years old getting cut off. It's getting cut off because anything above 100 will be outside of our standard age grid. Replacing the upper limit as 95 - 100 rather than 95 - 125 from the age metadata.