### PR TITLE
DISMODAT-700: Fixing the age cutoffs at 92.5 years bug (PMO-179)

### DIFF
--- a/src/cascade_at/inputs/base_input.py
+++ b/src/cascade_at/inputs/base_input.py
@@ -14,16 +14,21 @@ class BaseInput:
             'name', 'hold_out', 'density', 'eta', 'nu'
         ]
 
-    def convert_to_age_lower_upper(self, df):
+    def convert_to_age_lower_upper(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Converts a data frame that has age_group_id to
         age lower and upper based on age group metadata.
-        :param df: (pd.DataFrame) data frame with column
-            age_group_id
-        :return: (pd.DataFrame)
+        Replaces the age_upper of 125 with 100 for the 95+ age
+        group ID 235.
+
+        Parameters
+        ----------
+        df
+            A data frame that has age group ID
         """
         df.age_group_id = df.age_group_id.astype(int)
         df = df.merge(self.age_group_metadata, on='age_group_id')
+        df.loc[df.age_upper == 125., 'age_upper'] = 100.
         return df
 
     def keep_only_necessary_columns(self, df):

--- a/tests/dismod/api/test_dismod_extractor.py
+++ b/tests/dismod/api/test_dismod_extractor.py
@@ -30,7 +30,7 @@ def test_run_dismod_fit_predict(dismod, ihme, df):
 def test_get_predictions(ihme, dismod, df):
     d = DismodExtractor(path=Path('temp.db'))
     pred = d._extract_raw_predictions()
-    assert len(pred) == 484
+    assert len(pred) == 506
     assert all(pred.columns == [
         'predict_id', 'sample_index', 'avgint_id', 'avg_integrand',
         'integrand_id', 'node_id', 'weight_id', 'subgroup_id', 'age_lower',
@@ -45,7 +45,7 @@ def test_format_fit(ihme, dismod, df):
     pred = d.format_predictions_for_ihme(gbd_round_id=6, samples=False)
     # This prediction data frame is longer for each demographic group than the prediction
     # dataframe in `test_get_predictions` because there is an extra measure.
-    assert len(pred) == 528
+    assert len(pred) == 552
     assert all(pred.columns == [
         'location_id', 'year_id', 'age_group_id', 'sex_id', 'measure_id', 'mean'
     ])


### PR DESCRIPTION
This PR needs to stay open until we decide how to work with this issue. Either we need to replace the age upper for the terminal age group with 100 (what this PR does) or instruct modelers to have 125 as the upper age in their age/time grids.

Also, not all tests pass on this yet.