### PR TITLE
Viz covariate as rate name mod

### DIFF
--- a/src/cascade_at/inputs/utilities/covariate_specifications.py
+++ b/src/cascade_at/inputs/utilities/covariate_specifications.py
@@ -93,8 +93,13 @@ class EpiVizCovariateMultiplier:
         and integrand are strings."""
         id_to_integrand = make_integrand_map()
         if self.group == "alpha":
-            rate_measure = id_to_integrand[self.grid_spec.measure_id].name
-            measure = PRIMARY_INTEGRANDS_TO_RATES[rate_measure]
+            if self.grid_spec.measure_id in ['pini', 'iota', 'rho', 'chi', 'omega']:
+                # New EpiVis returns rate names for the rate covariates.
+                measure = self.grid_spec.measure_id
+            else:
+                # Old EpiVis returns of integrand measure id's for rate covariates.
+                rate_measure = id_to_integrand[int(self.grid_spec.measure_id)].name
+                measure = PRIMARY_INTEGRANDS_TO_RATES[rate_measure]
         else:
             measure = id_to_integrand[self.grid_spec.measure_id].name
         return self.covariate.name, measure

--- a/src/cascade_at/settings/settings_config.py
+++ b/src/cascade_at/settings/settings_config.py
@@ -183,7 +183,7 @@ class Smoothing(Form):
 class StudyCovariate(Form):
     study_covariate_id: IntField = IntField(display="Covariate")
 
-    measure_id: IntField = IntField(display="Measure")
+    measure_id: StrField = StrField(display="Measure")
     mulcov_type: OptionField = OptionField(
         ["rate_value", "meas_value", "meas_std"], display="Multiplier type")
     transformation: IntField = IntField(display="Transformation")
@@ -204,7 +204,7 @@ class StudyCovariate(Form):
 class CountryCovariate(Form):
     country_covariate_id: IntField = IntField(display="Covariate")
 
-    measure_id: IntField = IntField(display="Measure")
+    measure_id: StrField = StrField(display="Measure")
     mulcov_type: OptionField = OptionField(
         ["rate_value", "meas_value", "meas_std"], display="Multiplier type")
     transformation: IntField = IntField(display="Transformation")


### PR DESCRIPTION
This mod was required to handle a change to EpiVis covariate menus  made to show only rates (not integrands) in the measure menu when multiplier_type is rate_value. This messes up the code slightly as a rate name is not in a variable called "measure_id".